### PR TITLE
Add optional per-exercise RPE and feedback

### DIFF
--- a/docs/DATA-MODEL.md
+++ b/docs/DATA-MODEL.md
@@ -80,13 +80,22 @@ empty workout for a day before exercises are added.
 An exercise **inside** a workout — a name reference plus the logged sets. Distinct
 from `Exercise`.
 
-| Field          | Type     | Purpose                                               | Default                         |
-| -------------- | -------- | ----------------------------------------------------- | ------------------------------- |
-| `exerciseName` | `string` | Reference to an `Exercise` by its `name` (not an id). | required                        |
-| `sets`         | `Set[]`  | Sets performed; 1–5 entries.                          | `[{ set:1, weight:0, reps:0 }]` |
+| Field          | Type             | Purpose                                                 | Default                         |
+| -------------- | ---------------- | ------------------------------------------------------- | ------------------------------- |
+| `exerciseName` | `string`         | Reference to an `Exercise` by its `name` (not an id).   | required                        |
+| `sets`         | `Set[]`          | Sets performed; 1–5 entries.                            | `[{ set:1, weight:0, reps:0 }]` |
+| `rpe`          | `number \| null` | Optional rate of perceived exertion, 6–10 in 0.5 steps. | `null`                          |
+| `feedback`     | `string`         | Optional free-text note reviewing the exercise.         | `""`                            |
 
 Because the link is by name, renaming or deleting an exercise does **not** rewrite
 historical `exerciseName` values; past workouts keep the original name.
+
+`rpe` and `feedback` are both **optional** and authored by the user after a set.
+On import they pass through `normalizeRpe` / `normalizeFeedback` (`src/lib/rpe.js`):
+`rpe` is coerced to a number snapped to the nearest 0.5 within `[6, 10]` (anything
+else becomes `null`); `feedback` is coerced to a string capped at 2000 chars. Free
+text is safe because all storage and export round-trips through
+`JSON.stringify`/`JSON.parse` — no manual escaping is involved.
 
 ### Set
 

--- a/src/components/ExerciseHistoryModal.jsx
+++ b/src/components/ExerciseHistoryModal.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import RpeFeedback from "./RpeFeedback";
 import { Button } from "./ui/Button";
 import { Badge } from "./ui/Badge";
 import { CalendarIcon } from "./ui/Icons";
@@ -73,6 +74,14 @@ export default function ExerciseHistoryModal({
                       {s.reps}
                     </Badge>
                   ))}
+                </div>
+                {/* RPE + feedback, when logged */}
+                <div className="ml-4">
+                  <RpeFeedback
+                    mode="read"
+                    rpe={item.rpe ?? null}
+                    feedback={item.feedback ?? ""}
+                  />
                 </div>
               </div>
             );

--- a/src/components/RpeFeedback.jsx
+++ b/src/components/RpeFeedback.jsx
@@ -1,0 +1,129 @@
+import React, { useState } from "react";
+import { Button } from "./ui/Button";
+import { Textarea } from "./ui/Input";
+import { Plus, Pencil } from "./ui/Icons";
+import { RPE_OPTIONS, MAX_FEEDBACK_LEN, hasRpeFeedback } from "../lib/rpe";
+
+/**
+ * Optional RPE (rate of perceived exertion) + free-text feedback for a single
+ * exercise within a workout. RPE is a number 6–10 in 0.5 steps (blank = unset);
+ * feedback is free text. Both are optional.
+ *
+ * Two modes:
+ * - mode="edit" (default): collapsed "+ RPE / note" trigger that expands to an
+ *   RPE dropdown and a notes textarea. When collapsed with data present, shows a
+ *   clickable summary chip so logged values stay visible without expanding.
+ * - mode="read": static RPE badge + feedback text for history / modal views.
+ *
+ * Props:
+ * - rpe (number|null)   Current RPE, or null when unset.
+ * - feedback (string)   Current feedback text ("" when unset).
+ * - onChange (fn)       Edit mode only. Receives a patch: { rpe } or { feedback }.
+ * - mode ("edit"|"read")  Defaults to "edit".
+ *
+ * Local state: `open` — whether the editor is expanded (edit mode only).
+ */
+export default function RpeFeedback({
+  rpe = null,
+  feedback = "",
+  onChange = () => {},
+  mode = "edit",
+}) {
+  const [open, setOpen] = useState(false);
+  const filled = hasRpeFeedback(rpe, feedback);
+
+  const rpeBadge =
+    rpe != null ? (
+      <span className="shrink-0 rounded-xl border border-cyan-300 bg-cyan-50 px-2 py-0.5 text-xs font-medium text-cyan-800">
+        RPE {rpe}
+      </span>
+    ) : null;
+
+  if (mode === "read") {
+    if (!filled) return null;
+    return (
+      <div className="flex items-start gap-2">
+        {rpeBadge}
+        {feedback.trim() !== "" && (
+          <span className="whitespace-pre-wrap text-sm text-neutral-600">
+            {feedback}
+          </span>
+        )}
+      </div>
+    );
+  }
+
+  // Edit mode, collapsed.
+  if (!open) {
+    if (!filled) {
+      return (
+        <button
+          type="button"
+          onClick={() => setOpen(true)}
+          className="inline-flex items-center gap-1 text-xs text-neutral-600 hover:text-neutral-900"
+        >
+          <Plus /> RPE / note
+        </button>
+      );
+    }
+    return (
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="flex max-w-full items-center gap-2 rounded-xl border px-2.5 py-1.5 text-left hover:bg-neutral-50"
+      >
+        {rpeBadge}
+        {feedback.trim() !== "" && (
+          <span className="truncate text-sm text-neutral-600">{feedback}</span>
+        )}
+        <span className="ml-auto shrink-0 text-neutral-400">
+          <Pencil />
+        </span>
+      </button>
+    );
+  }
+
+  // Edit mode, expanded.
+  return (
+    <div className="space-y-2 border-t border-dashed pt-2">
+      <div className="flex items-center gap-2">
+        <label className="w-9 text-xs text-neutral-600" htmlFor="rpe-select">
+          RPE
+        </label>
+        <select
+          id="rpe-select"
+          className="rounded-xl border px-2 py-1.5 text-sm"
+          value={rpe == null ? "" : String(rpe)}
+          onChange={(e) =>
+            onChange({
+              rpe: e.target.value === "" ? null : Number(e.target.value),
+            })
+          }
+        >
+          <option value="">—</option>
+          {RPE_OPTIONS.map((v) => (
+            <option key={v} value={v}>
+              {v}
+            </option>
+          ))}
+        </select>
+        <span className="text-xs text-neutral-400">optional</span>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="ml-auto"
+          onClick={() => setOpen(false)}
+        >
+          Done
+        </Button>
+      </div>
+      <Textarea
+        rows={2}
+        maxLength={MAX_FEEDBACK_LEN}
+        placeholder="Feedback / notes (optional)"
+        value={feedback}
+        onChange={(e) => onChange({ feedback: e.target.value })}
+      />
+    </div>
+  );
+}

--- a/src/components/RpeFeedback.test.jsx
+++ b/src/components/RpeFeedback.test.jsx
@@ -1,0 +1,93 @@
+import React, { useState } from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import RpeFeedback from "./RpeFeedback";
+
+/** Controlled harness: applies { rpe } / { feedback } patches like the editors. */
+function Harness({ initialRpe = null, initialFeedback = "", spy }) {
+  const [state, setState] = useState({
+    rpe: initialRpe,
+    feedback: initialFeedback,
+  });
+  return (
+    <RpeFeedback
+      rpe={state.rpe}
+      feedback={state.feedback}
+      onChange={(patch) => {
+        spy?.(patch);
+        setState((prev) => ({ ...prev, ...patch }));
+      }}
+    />
+  );
+}
+
+describe("RpeFeedback (edit mode)", () => {
+  it("starts collapsed with a trigger when there is no data", () => {
+    render(<Harness />);
+    expect(
+      screen.getByRole("button", { name: /RPE \/ note/i }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
+  });
+
+  it("expands to a dropdown offering 6–10 in 0.5 steps and records a pick", async () => {
+    const user = userEvent.setup();
+    const spy = vi.fn();
+    render(<Harness spy={spy} />);
+
+    await user.click(screen.getByRole("button", { name: /RPE \/ note/i }));
+    const select = screen.getByRole("combobox");
+    // Blank + 9 options (6 … 10).
+    expect(screen.getAllByRole("option")).toHaveLength(10);
+
+    await user.selectOptions(select, "7.5");
+    expect(spy).toHaveBeenCalledWith({ rpe: 7.5 });
+  });
+
+  it("sends a feedback patch as the user types", async () => {
+    const user = userEvent.setup();
+    const spy = vi.fn();
+    render(<Harness spy={spy} />);
+
+    await user.click(screen.getByRole("button", { name: /RPE \/ note/i }));
+    await user.type(screen.getByPlaceholderText(/feedback/i), "tough");
+
+    expect(spy.mock.calls.at(-1)[0]).toEqual({ feedback: "tough" });
+  });
+
+  it("shows a summary chip when collapsed with data present", () => {
+    render(<Harness initialRpe={9} initialFeedback="back rounded" />);
+    expect(screen.getByText("RPE 9")).toBeInTheDocument();
+    expect(screen.getByText("back rounded")).toBeInTheDocument();
+    // Still collapsed — no dropdown yet.
+    expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
+  });
+
+  it("clears the rpe back to null when the blank option is chosen", async () => {
+    const user = userEvent.setup();
+    const spy = vi.fn();
+    render(<Harness initialRpe={8} spy={spy} />);
+
+    await user.click(screen.getByText("RPE 8"));
+    await user.selectOptions(screen.getByRole("combobox"), "—");
+    expect(spy).toHaveBeenCalledWith({ rpe: null });
+  });
+});
+
+describe("RpeFeedback (read mode)", () => {
+  it("renders nothing when there is no data", () => {
+    const { container } = render(
+      <RpeFeedback mode="read" rpe={null} feedback="" />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders the badge and feedback text when present", () => {
+    render(<RpeFeedback mode="read" rpe={8.5} feedback="grind on last set" />);
+    expect(screen.getByText("RPE 8.5")).toBeInTheDocument();
+    expect(screen.getByText("grind on last set")).toBeInTheDocument();
+    // Read mode is static — no inputs.
+    expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/WorkoutExerciseEditor.jsx
+++ b/src/components/WorkoutExerciseEditor.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import WeightRepInputs from "./WeightRepInputs";
+import RpeFeedback from "./RpeFeedback";
 import { Button } from "./ui/Button";
 import { Plus, Trash2 } from "./ui/Icons";
 import { fromDisplayWeight, toDisplayWeight } from "../lib/units";
@@ -158,6 +159,15 @@ export default function WorkoutExerciseEditor({
         >
           <Plus /> Set
         </Button>
+      </div>
+
+      {/* Optional RPE + feedback for this exercise */}
+      <div className="mt-2">
+        <RpeFeedback
+          rpe={item.rpe ?? null}
+          feedback={item.feedback ?? ""}
+          onChange={onChange}
+        />
       </div>
     </div>
   );

--- a/src/components/WorkoutHistoryItem.jsx
+++ b/src/components/WorkoutHistoryItem.jsx
@@ -4,6 +4,7 @@ import { Button } from "./ui/Button";
 import { Plus, Trash2, ChevronDown } from "./ui/Icons";
 import AddExerciseInput from "./AddExerciseInput";
 import WeightRepInputs from "./WeightRepInputs";
+import RpeFeedback from "./RpeFeedback";
 import { fromDisplayWeight, toDisplayWeight } from "../lib/units";
 import { useConfirm } from "./ConfirmDialog";
 import { MAX_SETS } from "../lib/constants";
@@ -298,6 +299,21 @@ export default function WorkoutHistoryItem({
                       <Plus /> Add set
                     </Button>
                   )}
+                </div>
+
+                {/* Optional RPE + feedback for this exercise */}
+                <div className="mt-2">
+                  <RpeFeedback
+                    rpe={we.rpe ?? null}
+                    feedback={we.feedback ?? ""}
+                    onChange={(patch) =>
+                      updateWorkout(w.id, {
+                        exercises: w.exercises.map((e2, i2) =>
+                          i2 === idx ? { ...e2, ...patch } : e2,
+                        ),
+                      })
+                    }
+                  />
                 </div>
               </div>
             ))}

--- a/src/components/WorkoutPlanner.jsx
+++ b/src/components/WorkoutPlanner.jsx
@@ -12,6 +12,7 @@ import { createExerciseEntry } from "../lib/exerciseUtils";
 import { useApp } from "../context/AppContext";
 import { moveItem } from "../lib/arrayUtils";
 import { MAX_SETS } from "../lib/constants";
+import { normalizeRpe, normalizeFeedback } from "../lib/rpe";
 
 /**
  * Planner component for creating a new workout.  Uses AppContext
@@ -63,6 +64,8 @@ export default function WorkoutPlanner({ onCreated }) {
           weight: Number(s.weight) || 0,
           reps: Number(s.reps) || 0,
         })),
+        rpe: normalizeRpe(i.rpe),
+        feedback: normalizeFeedback(i.feedback),
       })),
     }));
     setWorkouts((prev) =>

--- a/src/lib/backup.js
+++ b/src/lib/backup.js
@@ -1,5 +1,6 @@
 import { todayStr, uuid } from "./storage";
 import { MAX_SETS } from "./constants";
+import { normalizeRpe, normalizeFeedback } from "./rpe";
 
 export function downloadJSON(filename, data) {
   const blob = new Blob([JSON.stringify(data, null, 2)], {
@@ -47,6 +48,8 @@ export function normalizeWorkout(w) {
       return {
         exerciseName,
         sets: sets.length ? sets : [{ set: 1, weight: 0, reps: 0 }],
+        rpe: normalizeRpe(e?.rpe),
+        feedback: normalizeFeedback(e?.feedback),
       };
     })
     .filter(Boolean);

--- a/src/lib/backup.test.js
+++ b/src/lib/backup.test.js
@@ -96,6 +96,29 @@ describe("normalizeWorkout", () => {
     expect(w.name).toBe("2026-06-01");
   });
 
+  it("normalizes per-exercise rpe and feedback, dropping out-of-range rpe", () => {
+    const w = normalizeWorkout({
+      date: "2026-06-01",
+      exercises: [
+        { exerciseName: "Squat", sets: [], rpe: 7.5, feedback: "  solid  " },
+        { exerciseName: "Bench", sets: [], rpe: 99, feedback: 12345 },
+      ],
+    });
+    expect(w.exercises[0].rpe).toBe(7.5);
+    expect(w.exercises[0].feedback).toBe("  solid  ");
+    expect(w.exercises[1].rpe).toBeNull();
+    expect(w.exercises[1].feedback).toBe("");
+  });
+
+  it("defaults rpe to null and feedback to '' when absent", () => {
+    const w = normalizeWorkout({
+      date: "2026-06-01",
+      exercises: [{ exerciseName: "Squat", sets: [] }],
+    });
+    expect(w.exercises[0].rpe).toBeNull();
+    expect(w.exercises[0].feedback).toBe("");
+  });
+
   it("slices a full ISO datetime down to YYYY-MM-DD", () => {
     const w = normalizeWorkout({
       date: "2026-06-01T10:30:00.000Z",

--- a/src/lib/rpe.js
+++ b/src/lib/rpe.js
@@ -1,0 +1,44 @@
+// RPE (rate of perceived exertion) helpers.
+//
+// RPE is logged per workout-exercise as an optional number from 6 to 10 in
+// 0.5 steps; feedback is an optional free-text note. Both default to "unset"
+// (rpe = null, feedback = ""). These helpers are the validation boundary for
+// imported data — anything out of range or non-numeric collapses to null so a
+// bad backup can never poison the dropdown.
+
+export const RPE_MIN = 6;
+export const RPE_MAX = 10;
+export const RPE_STEP = 0.5;
+export const MAX_FEEDBACK_LEN = 2000;
+
+// The values offered in the dropdown: 6, 6.5, 7, … 10.
+export const RPE_OPTIONS = Array.from(
+  { length: Math.round((RPE_MAX - RPE_MIN) / RPE_STEP) + 1 },
+  (_, i) => RPE_MIN + i * RPE_STEP,
+);
+
+// Coerce an arbitrary value to a valid RPE: a number snapped to the nearest
+// 0.5 within [6, 10]. Anything non-numeric or out of range returns null.
+export function normalizeRpe(value) {
+  if (value === null || value === undefined || value === "") return null;
+  const n = Number(value);
+  if (!Number.isFinite(n)) return null;
+  const snapped = Math.round(n / RPE_STEP) * RPE_STEP;
+  if (snapped < RPE_MIN || snapped > RPE_MAX) return null;
+  // Avoid float artifacts (e.g. 7.5000000001) from the multiply/divide above.
+  return Math.round(snapped * 10) / 10;
+}
+
+// Coerce an arbitrary value to feedback text: a string capped at the max
+// length. Non-strings become "".
+export function normalizeFeedback(value) {
+  if (typeof value !== "string") return "";
+  return value.slice(0, MAX_FEEDBACK_LEN);
+}
+
+// True when an exercise carries any RPE/feedback worth showing.
+export function hasRpeFeedback(rpe, feedback) {
+  return (
+    rpe != null || (typeof feedback === "string" && feedback.trim() !== "")
+  );
+}

--- a/src/lib/rpe.test.js
+++ b/src/lib/rpe.test.js
@@ -1,0 +1,83 @@
+import {
+  RPE_OPTIONS,
+  RPE_MIN,
+  RPE_MAX,
+  MAX_FEEDBACK_LEN,
+  normalizeRpe,
+  normalizeFeedback,
+  hasRpeFeedback,
+} from "./rpe";
+
+describe("RPE_OPTIONS", () => {
+  it("runs 6 to 10 in 0.5 steps", () => {
+    expect(RPE_OPTIONS[0]).toBe(RPE_MIN);
+    expect(RPE_OPTIONS.at(-1)).toBe(RPE_MAX);
+    expect(RPE_OPTIONS).toEqual([6, 6.5, 7, 7.5, 8, 8.5, 9, 9.5, 10]);
+  });
+});
+
+describe("normalizeRpe", () => {
+  it("returns null for unset / non-numeric input", () => {
+    expect(normalizeRpe(null)).toBeNull();
+    expect(normalizeRpe(undefined)).toBeNull();
+    expect(normalizeRpe("")).toBeNull();
+    expect(normalizeRpe("abc")).toBeNull();
+    expect(normalizeRpe(NaN)).toBeNull();
+  });
+
+  it("returns null for values outside 6–10", () => {
+    expect(normalizeRpe(5.5)).toBeNull();
+    expect(normalizeRpe(0)).toBeNull();
+    expect(normalizeRpe(11)).toBeNull();
+    expect(normalizeRpe(-3)).toBeNull();
+  });
+
+  it("keeps valid in-range values", () => {
+    expect(normalizeRpe(6)).toBe(6);
+    expect(normalizeRpe(7.5)).toBe(7.5);
+    expect(normalizeRpe(10)).toBe(10);
+    expect(normalizeRpe("8")).toBe(8);
+  });
+
+  it("snaps to the nearest 0.5 step", () => {
+    expect(normalizeRpe(7.3)).toBe(7.5);
+    expect(normalizeRpe(7.2)).toBe(7);
+    expect(normalizeRpe(8.74)).toBe(8.5);
+  });
+
+  it("does not leak float artifacts", () => {
+    // 9.5 / 0.5 * 0.5 can drift; result must be exactly 9.5.
+    expect(normalizeRpe(9.5)).toBe(9.5);
+    expect(Number.isInteger(normalizeRpe(6.25) * 10)).toBe(true);
+  });
+});
+
+describe("normalizeFeedback", () => {
+  it("returns '' for non-strings", () => {
+    expect(normalizeFeedback(null)).toBe("");
+    expect(normalizeFeedback(undefined)).toBe("");
+    expect(normalizeFeedback(42)).toBe("");
+  });
+
+  it("preserves free text verbatim, including quotes and newlines", () => {
+    const text = 'Felt "heavy".\nGrip slipped — drop 5kg.';
+    expect(normalizeFeedback(text)).toBe(text);
+  });
+
+  it("caps length at MAX_FEEDBACK_LEN", () => {
+    const long = "x".repeat(MAX_FEEDBACK_LEN + 500);
+    expect(normalizeFeedback(long)).toHaveLength(MAX_FEEDBACK_LEN);
+  });
+});
+
+describe("hasRpeFeedback", () => {
+  it("is false when both are empty", () => {
+    expect(hasRpeFeedback(null, "")).toBe(false);
+    expect(hasRpeFeedback(null, "   ")).toBe(false);
+  });
+
+  it("is true when either is present", () => {
+    expect(hasRpeFeedback(8, "")).toBe(true);
+    expect(hasRpeFeedback(null, "tough")).toBe(true);
+  });
+});


### PR DESCRIPTION
## What

Each exercise within a workout can now carry an optional **RPE** (rate of perceived exertion, 6–10 in 0.5 steps) and an optional **free-text feedback** note. Both are entirely optional and default to unset.

- **Authoring** — a collapsed `+ RPE / note` control under each exercise in the planner and the history editor. It expands to an RPE dropdown + notes textarea, and shows a compact `RPE 7.5` summary chip when filled so logged values stay visible while collapsed.
- **Reviewing past entries** — the exercise-history modal shows a read-only RPE badge + feedback for every past workout.
- **Export/import** — the two fields live on `WorkoutExercise`, so they ride along in the JSON backup automatically. `normalizeWorkout` validates them on import.

## Data safety

`src/lib/rpe.js` is the single validation boundary:
- `normalizeRpe` coerces to a number snapped to the nearest 0.5 within [6, 10]; anything non-numeric or out of range becomes `null`, so a bad backup can't poison the dropdown.
- `normalizeFeedback` coerces to a string capped at 2000 chars.
- Free text is JSON-safe via the existing `JSON.stringify`/`parse` storage layer (no manual escaping anywhere), and React auto-escapes on render.

## Notes

- Verified end-to-end in the running app: authoring → persist across reload → history chip → read-only modal, with quotes and newlines round-tripping cleanly. No console errors.
- Caught and fixed during verification: the planner's save path was rebuilding each exercise and silently dropping the new fields.

## Tests

- `src/lib/rpe.test.js` — RPE_OPTIONS, snapping/clamping, feedback coercion.
- `src/components/RpeFeedback.test.jsx` — edit/read modes, collapse/expand, clearing.
- Extended `src/lib/backup.test.js` — import normalization of rpe/feedback.
- Full `npm run check` (lint + format + 113 tests + build) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)