### PR TITLE
Add period selector and gap-filling to weight chart

### DIFF
--- a/src/components/WeightChart.jsx
+++ b/src/components/WeightChart.jsx
@@ -1,26 +1,23 @@
 import React, { useMemo } from "react";
 import { loadLS, K_WEIGHT_LOGS } from "../lib/storage";
-import { startOfWeekMonday } from "../lib/dateUtils";
+import { buildWeightSeries } from "../lib/weightSeries";
 
 /**
- * A simple SVG line chart component. Accepts an array of points
- * with x/y coordinates and draws a polyline with markers and labels.
- * The width of the chart is configurable to support horizontal scrolling.
+ * A simple SVG line chart. Fits the width of its container (no horizontal
+ * scrolling) and samples labels so long ranges stay readable. Markers are
+ * only drawn when the series is short enough not to look noisy.
  */
-function SimpleLineChart({ points, height = 160, width, padding = 24 }) {
+function SimpleLineChart({ points, height = 200, width = 720, padding = 32 }) {
   if (!points || points.length < 2) {
     return (
       <div className="text-sm text-neutral-500">Not enough data to plot.</div>
     );
   }
-  const xs = points.map((p) => p.x);
   const ys = points.map((p) => p.y);
-  const minX = Math.min(...xs);
-  const maxX = Math.max(...xs);
   const minY = Math.min(...ys);
   const maxY = Math.max(...ys);
-  const scaleX = (x) =>
-    padding + ((x - minX) / (maxX - minX || 1)) * (width - padding * 2);
+  const lastIdx = points.length - 1;
+  const scaleX = (x) => padding + (x / (lastIdx || 1)) * (width - padding * 2);
   const scaleY = (y) =>
     height -
     padding -
@@ -28,36 +25,60 @@ function SimpleLineChart({ points, height = 160, width, padding = 24 }) {
   const linePoints = points
     .map((p) => `${scaleX(p.x)},${scaleY(p.y)}`)
     .join(" ");
+
+  // Show at most ~8 labels along the axis, always including the last point.
+  const labelStep = Math.max(1, Math.ceil(points.length / 8));
+  const showLabel = (i) => i === lastIdx || i % labelStep === 0;
+  // Markers get noisy past ~40 points; hide them on long ranges.
+  const showMarkers = points.length <= 40;
+
   return (
     <svg
-      width={width}
-      height={height}
       viewBox={`0 0 ${width} ${height}`}
+      preserveAspectRatio="none"
       className="w-full"
+      style={{ height }}
     >
       {/* line */}
       <polyline
         fill="none"
         stroke="currentColor"
         strokeWidth="2"
+        vectorEffect="non-scaling-stroke"
         points={linePoints}
       />
-      {/* point markers + labels */}
       {points.map((p, i) => {
         const cx = scaleX(p.x);
         const cy = scaleY(p.y);
+        const labelled = showLabel(i);
         return (
           <g key={i}>
-            <circle cx={cx} cy={cy} r="3" fill="currentColor" />
-            <text
-              x={cx}
-              y={cy - 8}
-              fontSize="10"
-              textAnchor="middle"
-              fill="currentColor"
-            >
-              {p.label}: {p.y}
-            </text>
+            {showMarkers && (
+              <circle cx={cx} cy={cy} r="3" fill="currentColor" />
+            )}
+            {labelled && (
+              <>
+                <text
+                  x={cx}
+                  y={cy - 8}
+                  fontSize="10"
+                  textAnchor="middle"
+                  fill="currentColor"
+                >
+                  {p.y}
+                </text>
+                <text
+                  x={cx}
+                  y={height - padding + 14}
+                  fontSize="9"
+                  textAnchor="middle"
+                  fill="currentColor"
+                  opacity="0.6"
+                >
+                  {p.label}
+                </text>
+              </>
+            )}
           </g>
         );
       })}
@@ -66,65 +87,35 @@ function SimpleLineChart({ points, height = 160, width, padding = 24 }) {
 }
 
 /**
- * Scrollable line chart for displaying body‑weight logs. This component
- * renders a maximum of two weeks (14 days) at a time in daily mode or
- * twelve weeks in weekly mode. The most recent entries are shown,
- * and the chart scrolls horizontally when there are more slots than
- * displayed data. No external charting library is required.
+ * Line chart for body-weight logs over a selected period.
+ *
+ * Every day in [from, to] is plotted; days without a logged weight carry the
+ * most recent prior weight forward (see buildWeightSeries), so adjacent points
+ * always represent consecutive days. Weekly view averages the filled days per
+ * ISO week.
  *
  * Props:
- *   logs (optional) – an object mapping ISO date strings to weights.
- *   view – "daily" or "weekly" to determine aggregation.
+ *   logs (optional) – map of ISO date strings to weights (falls back to LS).
+ *   view – "daily" or "weekly".
+ *   from / to – Date range to plot.
  */
-export default function WeightChart({ logs, view = "daily" }) {
-  // Read weight logs from props or localStorage
+export default function WeightChart({ logs, view = "daily", from, to }) {
   const rawLogs = logs || loadLS(K_WEIGHT_LOGS, {});
-  // Normalize data according to view
-  const weightData = useMemo(() => {
-    const entries = Object.keys(rawLogs).sort();
-    if (view === "weekly") {
-      const byWeek = {};
-      entries.forEach((date) => {
-        const d = new Date(date + "T00:00:00");
-        const weekStart = startOfWeekMonday(d);
-        const wkKey = weekStart.toISOString().slice(0, 10);
-        if (!byWeek[wkKey]) byWeek[wkKey] = [];
-        byWeek[wkKey].push(rawLogs[date]);
-      });
-      return Object.keys(byWeek)
-        .sort()
-        .map((wk) => {
-          const weights = byWeek[wk];
-          const avg =
-            weights.reduce((sum, w) => sum + w, 0) / (weights.length || 1);
-          return { date: wk, weight: parseFloat(avg.toFixed(2)) };
-        });
-    }
-    return entries.map((date) => ({ date, weight: rawLogs[date] }));
-  }, [rawLogs, view]);
-  // Determine page size: 12 weeks or 14 days. This defines the width of the
-  // visible window (number of slots displayed at once).
-  const PAGE_SIZE = view === "weekly" ? 12 : 14;
-  // Convert all entries to points with sequential x values. We assign each
-  // record a zero-based index so that the x-axis spacing is uniform.
-  const points = useMemo(() => {
-    return weightData.map((row, idx) => {
-      const label = row.date.slice(5); // show MM-DD portion
-      return { x: idx, y: row.weight, label };
-    });
-  }, [weightData]);
-  // Full chart width based on the total number of points
-  const chartWidth = points.length * 60;
-  // Visible window width: fixed number of slots (PAGE_SIZE)
-  const visibleWidth = PAGE_SIZE * 60;
-  return (
-    <div>
-      {/* Wrapper with fixed width so only PAGE_SIZE points are visible at once */}
-      <div style={{ overflowX: "auto", width: `${visibleWidth}px` }}>
-        <div style={{ width: `${chartWidth}px` }}>
-          <SimpleLineChart points={points} width={chartWidth} />
-        </div>
-      </div>
-    </div>
+
+  const series = useMemo(
+    () => buildWeightSeries(rawLogs, from, to, view),
+    [rawLogs, from, to, view],
   );
+
+  const points = useMemo(
+    () =>
+      series.map((row, idx) => ({
+        x: idx,
+        y: row.weight,
+        label: row.date.slice(5), // MM-DD
+      })),
+    [series],
+  );
+
+  return <SimpleLineChart points={points} />;
 }

--- a/src/components/WeightTracker.jsx
+++ b/src/components/WeightTracker.jsx
@@ -15,6 +15,7 @@ import {
   endOfWeekSunday,
 } from "../lib/dateUtils";
 import { averageWeightInRange } from "../lib/weightUtils";
+import { rangeForPeriod } from "../lib/weightSeries";
 
 function weekRangeOf(date) {
   const from = startOfWeekMonday(date);
@@ -71,6 +72,20 @@ export default function WeightTracker() {
 
   // Graph data toggle: "daily" | "weekly"
   const [mode, setMode] = useState("daily");
+
+  // Chart period: "1m" | "3m" | "6m" | "1y" | "custom"
+  const [period, setPeriod] = useState("3m");
+  const [customFrom, setCustomFrom] = useState("");
+  const [customTo, setCustomTo] = useState("");
+
+  const { from: chartFrom, to: chartTo } = useMemo(() => {
+    if (period === "custom") {
+      const f = customFrom ? new Date(customFrom + "T00:00:00") : null;
+      const t = customTo ? new Date(customTo + "T00:00:00") : new Date();
+      return { from: f, to: t };
+    }
+    return rangeForPeriod(period);
+  }, [period, customFrom, customTo]);
 
   const onCellClick = (date) => {
     const key = ymdFromDate(date);
@@ -206,6 +221,7 @@ export default function WeightTracker() {
 
       {/* Trend graph with markers + labels (day/value) */}
       <div className="space-y-2">
+        {/* Daily / Weekly view toggle */}
         <div className="flex gap-2">
           <Button
             variant={mode === "daily" ? "primary" : "secondary"}
@@ -220,17 +236,72 @@ export default function WeightTracker() {
             Weekly
           </Button>
         </div>
+
+        {/* Period selector */}
+        <div className="flex flex-wrap gap-2">
+          {[
+            ["1m", "1M"],
+            ["3m", "3M"],
+            ["6m", "6M"],
+            ["1y", "1Y"],
+            ["custom", "Custom"],
+          ].map(([key, label]) => (
+            <Button
+              key={key}
+              variant={period === key ? "primary" : "secondary"}
+              onClick={() => setPeriod(key)}
+            >
+              {label}
+            </Button>
+          ))}
+        </div>
+
+        {/* Custom range inputs */}
+        {period === "custom" && (
+          <div className="flex flex-wrap items-center gap-2 text-sm">
+            <label className="flex items-center gap-1">
+              <span className="text-neutral-500">From</span>
+              <input
+                type="date"
+                className="border rounded px-2 py-1"
+                value={customFrom}
+                max={customTo || todayYmd}
+                onChange={(e) => setCustomFrom(e.target.value)}
+              />
+            </label>
+            <label className="flex items-center gap-1">
+              <span className="text-neutral-500">To</span>
+              <input
+                type="date"
+                className="border rounded px-2 py-1"
+                value={customTo}
+                min={customFrom || undefined}
+                onChange={(e) => setCustomTo(e.target.value)}
+              />
+            </label>
+          </div>
+        )}
+
         {/*
-          Use the WeightChart component to render the line chart. It
-          automatically aggregates data based on the view (daily or
-          weekly) and renders a horizontally scrollable graph. The
-          window displays at most 14 days or 12 weeks at once, but
-          you can scroll left/right to view the rest of your weight
-          history. Passing the logs ensures it uses the same data
-          that WeightTracker manages.
+          WeightChart plots every day in the selected range. Days without a
+          logged weight carry the last recorded weight forward, so adjacent
+          points always represent consecutive days. Weekly view averages the
+          filled days per ISO week. Passing the logs ensures it uses the same
+          data that WeightTracker manages.
         */}
-        <div className="rounded-lg border p-3 overflow-x-auto">
-          <WeightChart view={mode} logs={logs} />
+        <div className="rounded-lg border p-3">
+          {period === "custom" && !customFrom ? (
+            <div className="text-sm text-neutral-500">
+              Pick a start date to plot a custom range.
+            </div>
+          ) : (
+            <WeightChart
+              view={mode}
+              logs={logs}
+              from={chartFrom}
+              to={chartTo}
+            />
+          )}
         </div>
       </div>
     </div>

--- a/src/lib/weightSeries.js
+++ b/src/lib/weightSeries.js
@@ -1,0 +1,110 @@
+// Builds chart-ready weight series from a body-weight log map
+// ({ "YYYY-MM-DD": number }), filling gaps so the x-axis is continuous.
+
+import { ymdFromDate } from "./date";
+import { startOfWeekMonday } from "./dateUtils";
+
+/**
+ * Produce a continuous daily series within [from, to] (inclusive).
+ *
+ * Days without a logged weight inherit the most recent prior weight
+ * (forward-fill / carry-forward), including weights logged before `from`.
+ * Leading days that have no prior weight at all are omitted, since there
+ * is nothing to carry yet.
+ *
+ * @param {Object<string, number>} logs - map of `YYYY-MM-DD` to weight.
+ * @param {Date} from - range start (inclusive).
+ * @param {Date} to - range end (inclusive).
+ * @returns {{date: string, weight: number}[]} one entry per day with a value.
+ */
+export function fillDailyWeights(logs, from, to) {
+  if (!from || !to) return [];
+  const fromKey = ymdFromDate(from);
+
+  // Seed with the most recent weight logged on or before the range start.
+  let lastWeight = null;
+  for (const date of Object.keys(logs).sort()) {
+    if (date <= fromKey) {
+      const v = logs[date];
+      if (typeof v === "number" && isFinite(v)) lastWeight = v;
+    } else {
+      break;
+    }
+  }
+
+  const out = [];
+  const cur = new Date(from);
+  cur.setHours(0, 0, 0, 0);
+  const end = new Date(to);
+  end.setHours(0, 0, 0, 0);
+  while (cur <= end) {
+    const key = ymdFromDate(cur);
+    const v = logs[key];
+    if (typeof v === "number" && isFinite(v)) lastWeight = v;
+    if (lastWeight != null) out.push({ date: key, weight: lastWeight });
+    cur.setDate(cur.getDate() + 1);
+  }
+  return out;
+}
+
+/**
+ * Build the chart series for the given period and view.
+ *
+ * Daily view returns the forward-filled daily series. Weekly view groups
+ * those filled days by ISO (Mon–Sun) week and averages them, so every week
+ * in the range is represented.
+ *
+ * @param {Object<string, number>} logs
+ * @param {Date} from
+ * @param {Date} to
+ * @param {"daily"|"weekly"} view
+ * @returns {{date: string, weight: number}[]}
+ */
+export function buildWeightSeries(logs, from, to, view = "daily") {
+  const daily = fillDailyWeights(logs, from, to);
+  if (view !== "weekly") return daily;
+
+  const byWeek = {};
+  daily.forEach(({ date, weight }) => {
+    const wk = ymdFromDate(startOfWeekMonday(new Date(date + "T00:00:00")));
+    (byWeek[wk] = byWeek[wk] || []).push(weight);
+  });
+  return Object.keys(byWeek)
+    .sort()
+    .map((wk) => {
+      const weights = byWeek[wk];
+      const avg = weights.reduce((a, b) => a + b, 0) / weights.length;
+      return { date: wk, weight: Math.round(avg * 100) / 100 };
+    });
+}
+
+/**
+ * Compute the [from, to] range for a named period ending at `today`.
+ * Custom ranges are handled by the caller.
+ *
+ * @param {"1m"|"3m"|"6m"|"1y"} period
+ * @param {Date} [today]
+ * @returns {{from: Date, to: Date}}
+ */
+export function rangeForPeriod(period, today = new Date()) {
+  const to = new Date(today);
+  to.setHours(0, 0, 0, 0);
+  const from = new Date(to);
+  switch (period) {
+    case "1m":
+      from.setMonth(from.getMonth() - 1);
+      break;
+    case "3m":
+      from.setMonth(from.getMonth() - 3);
+      break;
+    case "6m":
+      from.setMonth(from.getMonth() - 6);
+      break;
+    case "1y":
+      from.setFullYear(from.getFullYear() - 1);
+      break;
+    default:
+      from.setMonth(from.getMonth() - 3);
+  }
+  return { from, to };
+}

--- a/src/lib/weightSeries.test.js
+++ b/src/lib/weightSeries.test.js
@@ -1,0 +1,97 @@
+import { describe, it, expect } from "vitest";
+import {
+  fillDailyWeights,
+  buildWeightSeries,
+  rangeForPeriod,
+} from "./weightSeries";
+
+const d = (s) => new Date(s + "T00:00:00");
+
+describe("fillDailyWeights", () => {
+  it("emits one entry per day in the range", () => {
+    const logs = { "2026-01-01": 80 };
+    const out = fillDailyWeights(logs, d("2026-01-01"), d("2026-01-03"));
+    expect(out).toEqual([
+      { date: "2026-01-01", weight: 80 },
+      { date: "2026-01-02", weight: 80 },
+      { date: "2026-01-03", weight: 80 },
+    ]);
+  });
+
+  it("forward-fills gaps with the last logged weight", () => {
+    const logs = { "2026-01-01": 80, "2026-01-04": 82 };
+    const out = fillDailyWeights(logs, d("2026-01-01"), d("2026-01-05"));
+    expect(out.map((p) => p.weight)).toEqual([80, 80, 80, 82, 82]);
+  });
+
+  it("carries a weight logged before the range start", () => {
+    const logs = { "2025-12-20": 79 };
+    const out = fillDailyWeights(logs, d("2026-01-01"), d("2026-01-02"));
+    expect(out).toEqual([
+      { date: "2026-01-01", weight: 79 },
+      { date: "2026-01-02", weight: 79 },
+    ]);
+  });
+
+  it("omits leading days that have no prior weight", () => {
+    const logs = { "2026-01-03": 81 };
+    const out = fillDailyWeights(logs, d("2026-01-01"), d("2026-01-04"));
+    expect(out).toEqual([
+      { date: "2026-01-03", weight: 81 },
+      { date: "2026-01-04", weight: 81 },
+    ]);
+  });
+
+  it("ignores non-numeric / non-finite values", () => {
+    const logs = { "2026-01-01": 80, "2026-01-02": NaN, "2026-01-03": null };
+    const out = fillDailyWeights(logs, d("2026-01-01"), d("2026-01-03"));
+    expect(out.map((p) => p.weight)).toEqual([80, 80, 80]);
+  });
+
+  it("returns [] when range is missing", () => {
+    expect(
+      fillDailyWeights({ "2026-01-01": 80 }, null, d("2026-01-02")),
+    ).toEqual([]);
+  });
+});
+
+describe("buildWeightSeries weekly", () => {
+  it("averages filled days per ISO week", () => {
+    // Mon 2026-01-05 .. Sun 2026-01-11 is one week.
+    const logs = { "2026-01-05": 80, "2026-01-08": 84 };
+    const out = buildWeightSeries(
+      logs,
+      d("2026-01-05"),
+      d("2026-01-11"),
+      "weekly",
+    );
+    expect(out).toHaveLength(1);
+    expect(out[0].date).toBe("2026-01-05");
+    // 80,80,80,84,84,84,84 -> avg
+    expect(out[0].weight).toBeCloseTo((80 * 3 + 84 * 4) / 7, 2);
+  });
+
+  it("represents every week in the range via forward-fill", () => {
+    const logs = { "2026-01-05": 80 };
+    const out = buildWeightSeries(
+      logs,
+      d("2026-01-05"),
+      d("2026-01-18"),
+      "weekly",
+    );
+    expect(out.map((p) => p.weight)).toEqual([80, 80]);
+  });
+});
+
+describe("rangeForPeriod", () => {
+  const today = d("2026-06-13");
+  it("computes 1m / 3m / 6m / 1y back from today", () => {
+    expect(rangeForPeriod("1m", today).from).toEqual(d("2026-05-13"));
+    expect(rangeForPeriod("3m", today).from).toEqual(d("2026-03-13"));
+    expect(rangeForPeriod("6m", today).from).toEqual(d("2025-12-13"));
+    expect(rangeForPeriod("1y", today).from).toEqual(d("2025-06-13"));
+  });
+  it("ends at today", () => {
+    expect(rangeForPeriod("3m", today).to).toEqual(today);
+  });
+});


### PR DESCRIPTION
## What

Reworks the body-weight chart so it plots a **continuous, gap-filled series over a selectable period**, while keeping the existing Daily/Weekly toggle.

- **Period selector** — `1M / 3M / 6M / 1Y / Custom` above the chart. Custom reveals From/To date inputs (with min/max bounds) and shows a prompt until a start date is picked.
- **Every day in the range is plotted.** Days without a logged weight carry the most recent prior weight forward (forward-fill), including a weight logged *before* the range start. So two adjacent points always represent consecutive days — they no longer silently skip empty days.
- **Weekly view** averages the filled days per ISO (Mon–Sun) week, so every week in the range is represented.

## Why

Previously the chart plotted only logged days with uniform spacing, so two markers sitting side by side could actually be weeks apart, and the visible window was capped at 14 days / 12 weeks with horizontal scrolling.

## How

- New `src/lib/weightSeries.js`: `fillDailyWeights` (forward-fill), `buildWeightSeries` (daily/weekly), and `rangeForPeriod`. Co-located tests cover gap-fill, carry-from-before-range, leading-empty omission, non-finite handling, and weekly aggregation.
- `WeightChart` now takes `from`/`to`, fits its container width (no fixed-width scroll), samples x-axis labels (~8 max, always including the last point), and hides markers past 40 points to stay readable.
- `WeightTracker` owns the period/custom-range state and passes the range down.

## Notes for reviewers

- Leading days that have no prior weight at all are intentionally omitted — there's nothing to carry yet, so e.g. a 1Y range starting before any log begins at the first logged day.
- Weights are displayed as stored (no `toDisplayWeight` conversion), matching the existing calendar/chart behavior in this component — unchanged on purpose, out of scope here.

## Verification

`npm run check` passes (123 tests, lint, format, build). Manually verified in the browser preview across Daily/Weekly and all periods including a custom range.

🤖 Generated with [Claude Code](https://claude.com/claude-code)