### PR TITLE
UI/UX revamp: bottom-nav + dark theme + live-logging mode

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -245,7 +245,10 @@ set-by-set, persisted to `mgym.session.v1` so a refresh mid-workout resumes:
 
 When `session` is non-null, `App` renders `LiveSession` full-screen instead of the
 tabbed layout. Pure helpers (`setKey`, `toggleDone`, `doneCount`, `totalSets`,
-`formatClock`) live in `src/lib/liveSession.js`. Entry points: **Home**'s today
+`formatClock`) live in `src/lib/liveSession.js`. Exercises can be **reordered**
+mid-session (machines get taken); since the `done` map is keyed by exercise
+index, `remapDoneAfterMove` / `remapIndexAfterMove` shift those keys (and the
+on-screen pointer) to follow a `moveItem` reorder. Entry points: **Home**'s today
 card and each **WorkoutHistoryItem** ("▶ Start") call `startSession`; **Home** and
 the **Workouts** tab offer "Start empty workout" (`startEmptyWorkout`). `Finish`
 calls `endSession`, and drops the workout if it was left with zero exercises.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -14,10 +14,23 @@ browser's `localStorage`, so the app is local-first and works offline after the
 initial load. Data never leaves the device unless you explicitly use the Data
 menu to export a JSON backup.
 
-The UI is a single column with six tabs — **Workouts**, **Calendar**,
-**Exercises**, **Weight**, **Notepad**, and **Summary** — switched by buttons in
-the header. There is no client-side router; the active tab is a piece of shared
-state (and is itself persisted).
+The UI is a single centered column navigated by a **fixed five-tab bottom bar** —
+**Home**, **Workouts**, **Progress**, **Exercises**, **More**. There is no
+client-side router; the active tab is a piece of shared state (and is itself
+persisted). Several earlier top-level tabs were consolidated: **Progress** merges
+the old Weight + Summary views (Bodyweight / Strength toggle), **Calendar** folds
+into Workouts as a List/Calendar toggle, and **Notepad** + data export/import +
+preferences live under **More**. **Home** is a dashboard (greeting, streak,
+today's plan, week stats, recent activity). Legacy persisted `tab` values
+(`calendar`/`weight`/`summary`/`notepad`) are mapped onto the new destinations in
+`App.jsx` so returning users never land on a blank screen.
+
+Two things render **outside** this tabbed layout:
+
+- **Live-logging session** — when a workout session is active, `LiveSession`
+  takes over the whole screen (the bottom nav is hidden) for set-by-set logging.
+- **Theme** — a light/dark/system preference applied by toggling the `dark` class
+  on `<html>` (Tailwind class-based dark mode).
 
 ## Tech stack and the role of each tool
 
@@ -31,7 +44,9 @@ state (and is itself persisted).
 | **PostCSS**              | 8.4                      | CSS pipeline Tailwind plugs into. Config in `postcss.config.js`.                                                            |
 | **autoprefixer**         | 10.4                     | PostCSS plugin adding vendor prefixes at build time.                                                                        |
 
-There is **no TypeScript, router, or data-fetching library**. Charts (weight
+There is **no TypeScript, router, or data-fetching library**. Dark mode is
+class-based Tailwind (`darkMode: "class"` in `tailwind.config.js`); icons are
+inline SVG/emoji (no icon library). Charts (weight
 trend, muscle bars) are hand-rolled SVG — no charting dependency. Tests use
 **Vitest + React Testing Library** (see [docs/TESTING.md](docs/TESTING.md));
 ESLint + Prettier enforce style.
@@ -47,10 +62,10 @@ gym-tracker/
 ├── postcss.config.js          # Tailwind + autoprefixer
 └── src/
     ├── main.jsx               # Entry: mounts <App/>
-    ├── App.jsx                # Wraps AppProvider; renders header, tabs, active view
+    ├── App.jsx                # Wraps AppProvider; renders active view + BottomNav (or LiveSession)
     ├── index.css              # Tailwind directives + a few base styles
     ├── context/
-    │   └── AppContext.jsx     # Shared state (tab, unit, exercises, workouts) + persistence
+    │   └── AppContext.jsx     # Shared state (tab, unit, theme, exercises, workouts, session) + persistence
     ├── data/
     │   └── exercises_seed.json   # 76 default exercises (first-run seed)
     ├── lib/                   # Framework-free helpers
@@ -63,8 +78,16 @@ gym-tracker/
     │   ├── weightUtils.js        # averageWeightInRange for bodyweight logs
     │   ├── arrayUtils.js         # moveItem() reorder helper
     │   ├── constants.js          # MAX_SETS
-    │   └── metrics.js            # Period bucketing + per-period metrics (reps/sets/PRs)
+    │   ├── metrics.js            # Period bucketing + per-period metrics (reps/sets/PRs)
+    │   ├── homeStats.js          # Home dashboard: volume/streak/week helpers
+    │   ├── theme.js              # resolveDark / applyTheme (light|dark|system)
+    │   └── liveSession.js        # Live-session done-map + clock helpers
     └── components/
+        ├── Home.jsx                 # Home dashboard (Home tab)
+        ├── WorkoutsTab.jsx          # Workouts tab shell: List/Calendar toggle + Start
+        ├── Progress.jsx             # Progress tab shell: Bodyweight/Strength toggle
+        ├── MoreMenu.jsx             # More tab: prefs (theme), Notepad, data export/import
+        ├── LiveSession.jsx          # Full-screen set-by-set live workout logger
         ├── WorkoutPlanner.jsx       # "Plan / Log Workout" form (Workouts tab)
         ├── WorkoutHistory.jsx       # List of past workouts (Workouts tab)
         ├── WorkoutHistoryItem.jsx   # One history card: header + expanded editor
@@ -92,6 +115,8 @@ gym-tracker/
             ├── Input.jsx            # Input + Textarea
             ├── Card.jsx             # Card + CardContent
             ├── Badge.jsx            # Pill label
+            ├── BottomNav.jsx        # Fixed 5-tab bottom navigation (inline SVG icons)
+            ├── Segmented.jsx        # Pill segmented toggle (List/Calendar, etc.)
             ├── ComboInput.jsx       # <datalist>-backed free-text + suggestions
             └── Icons.jsx            # Emoji icon components
 ```
@@ -102,38 +127,38 @@ gym-tracker/
 main.jsx
 └── ConfirmProvider                 (single provider for all useConfirm() consumers)
     └── App
-        └── AppProvider             (Context: tab, unit, exercises, workouts)
+        └── AppProvider             (Context: tab, unit, theme, exercises, workouts, session)
             └── AppContent          (consumes useApp())
-                ├── DataManagementMenu        (header)
-                ├── Button (unit toggle, tab buttons)
                 │
-                ├── [tab="workouts"]
-                │   ├── WorkoutPlanner
-                │   │   ├── AddExerciseInput
-                │   │   ├── WorkoutExerciseEditor → WeightRepInputs / NumberInputAutoClear
-                │   │   └── ExerciseHistoryModal
-                │   └── WorkoutHistory
-                │       ├── WorkoutHistoryItem
-                │       │   ├── AddExerciseInput
-                │       │   └── WeightRepInputs / NumberInputAutoClear
-                │       └── ExerciseHistoryModal
+                ├── session active? → LiveSession        (full-screen; bottom nav hidden)
+                │       ├── WeightRepInputs / NumberInputAutoClear   (per-set inputs)
+                │       └── AddExerciseInput                          (add exercise mid-session)
                 │
-                ├── [tab="calendar"]  CalendarView → AddExerciseInput
-                │
-                ├── [tab="exercises"] ExerciseManager
-                │   ├── NewExerciseInline → ComboInput
-                │   ├── ExerciseRow → ComboInput
-                │   └── ExerciseHistoryModal
-                │
-                ├── [tab="weight"]    WeightTracker → WeightChart
-                │
-                ├── [tab="notepad"]   Notepad
-                │
-                └── [tab="summary"]   DashboardSummary
-                    └── PeriodCard
-                        ├── GroupedMuscleBar
-                        ├── Delta
-                        └── WeeklyNotes   (weekly periods only)
+                └── otherwise: <active view> + BottomNav
+                    │
+                    ├── [tab="home"]      Home            (dashboard; uses homeStats.js)
+                    │
+                    ├── [tab="workouts"]  WorkoutsTab     (Segmented: List | Calendar)
+                    │   ├── (list) WorkoutPlanner
+                    │   │       ├── AddExerciseInput
+                    │   │       ├── WorkoutExerciseEditor → WeightRepInputs / NumberInputAutoClear
+                    │   │       └── ExerciseHistoryModal
+                    │   ├── (list) WorkoutHistory → WorkoutHistoryItem  (▶ Start → live session)
+                    │   └── (calendar) CalendarView → AddExerciseInput
+                    │
+                    ├── [tab="progress"]  Progress        (Segmented: Bodyweight | Strength)
+                    │   ├── (bodyweight) WeightTracker → WeightChart
+                    │   └── (strength)   DashboardSummary → PeriodCard
+                    │                         ├── GroupedMuscleBar
+                    │                         ├── Delta
+                    │                         └── WeeklyNotes   (weekly periods only)
+                    │
+                    ├── [tab="exercises"] ExerciseManager (search + muscle-group chips)
+                    │   ├── NewExerciseInline → ComboInput
+                    │   ├── ExerciseRow → ComboInput
+                    │   └── ExerciseHistoryModal
+                    │
+                    └── [tab="more"]      MoreMenu        (theme; Notepad sub-screen; DataManagementMenu)
 ```
 
 ## State-management model
@@ -145,16 +170,24 @@ props.
 
 ### State owned by `AppProvider`
 
-| State       | Initial value                 | Purpose                         | Persisted to        |
-| ----------- | ----------------------------- | ------------------------------- | ------------------- |
-| `tab`       | `loadLS(K_TAB, "workouts")`   | Active tab                      | `mgym.tab`          |
-| `unit`      | `loadLS(K_UNIT, "kg")`        | Display unit (`"kg"` \| `"lb"`) | `mgym.unit`         |
-| `exercises` | `loadLS(K_EX, seedExercises)` | Exercise database               | `mgym.exercises.v1` |
-| `workouts`  | `loadLS(K_WO, [])`            | All logged/planned workouts     | `mgym.workouts.v1`  |
+| State       | Initial value                 | Purpose                                        | Persisted to        |
+| ----------- | ----------------------------- | ---------------------------------------------- | ------------------- |
+| `tab`       | `loadLS(K_TAB, "workouts")`   | Active tab (new IA; legacy values remapped)    | `mgym.tab`          |
+| `unit`      | `loadLS(K_UNIT, "kg")`        | Display unit (`"kg"` \| `"lb"`; toggle hidden) | `mgym.unit`         |
+| `theme`     | `loadLS(K_THEME, "system")`   | Theme pref (`"system"`\|`"light"`\|`"dark"`)   | `mgym.theme`        |
+| `exercises` | `loadLS(K_EX, seedExercises)` | Exercise database                              | `mgym.exercises.v1` |
+| `workouts`  | `loadLS(K_WO, [])`            | All logged/planned workouts                    | `mgym.workouts.v1`  |
+| `session`   | `loadLS(K_SESSION, null)`     | In-progress live-logging session (or `null`)   | `mgym.session.v1`   |
 
-All four are persisted by `useEffect`s in `AppProvider` that run whenever the
-value changes. (Unlike the earlier version of the app, **`unit` and `tab` are now
-persisted** too.)
+All six are persisted by `useEffect`s in `AppProvider` that run whenever the
+value changes. `theme` additionally triggers `applyTheme()` (toggles the `dark`
+class on `<html>`) and, while the preference is `"system"`, a `matchMedia`
+listener re-applies on OS light/dark changes.
+
+`AppProvider` also exposes live-session helpers: **`startSession(workoutId)`**
+(begin logging an existing workout), **`startEmptyWorkout()`** (create a fresh
+empty workout dated today, then start it), and **`endSession()`**. See
+[Live-logging session](#live-logging-session) below.
 
 ### How components get state
 
@@ -183,6 +216,39 @@ use). It is **derived from `workouts`**, not authored. An effect in
 `AppProvider` recomputes it whenever `workouts` changes and writes it back onto
 `exercises` — so the derived value is also persisted into `mgym.exercises.v1`.
 Treat it as a cache of `workouts`; it can briefly lag until the effect runs.
+
+### Theme
+
+`theme` is one of `"system" | "light" | "dark"`, persisted to `mgym.theme`.
+`src/lib/theme.js` resolves a preference to a concrete mode (`resolveDark`) and
+applies it (`applyTheme`) by toggling the `dark` class on `<html>`. Tailwind runs
+in class-based dark mode (`darkMode: "class"`), so every `dark:` utility keys off
+that class. The Light/Dark/Auto control lives in the **More** tab.
+
+### Live-logging session
+
+`session` is `null` or an object describing an in-progress workout being logged
+set-by-set, persisted to `mgym.session.v1` so a refresh mid-workout resumes:
+
+```js
+{
+  (workoutId, startedAt, currentIdx, done);
+}
+```
+
+- `workoutId` — the `Workout.id` being logged (the workout itself lives in
+  `workouts`; live edits write through to it).
+- `startedAt` — epoch ms, for the elapsed clock.
+- `currentIdx` — index of the exercise on screen.
+- `done` — a **flat map** of completed sets keyed `"exerciseIdx:setIdx"` → `true`.
+  This is transient session state; it is **not** stored on the `Set` itself.
+
+When `session` is non-null, `App` renders `LiveSession` full-screen instead of the
+tabbed layout. Pure helpers (`setKey`, `toggleDone`, `doneCount`, `totalSets`,
+`formatClock`) live in `src/lib/liveSession.js`. Entry points: **Home**'s today
+card and each **WorkoutHistoryItem** ("▶ Start") call `startSession`; **Home** and
+the **Workouts** tab offer "Start empty workout" (`startEmptyWorkout`). `Finish`
+calls `endSession`, and drops the workout if it was left with zero exercises.
 
 ## Data model
 
@@ -233,7 +299,9 @@ inventory is documented in
 }
 ```
 
-Downloaded as `gym-tracker-backup-<YYYY-MM-DD>.json`.
+Downloaded as `gym-tracker-backup-<YYYY-MM-DD>.json`. The `theme` preference and
+any in-progress live `session` are **not** included in the backup (they are
+device-local UI state, not data worth migrating).
 
 **Import** parses the file, runs exercises/workouts through `normalizeData()`
 (coerces/validates, drops invalid rows), then applies them in one of two modes:
@@ -291,6 +359,12 @@ by week/month and compute reps/sets-per-muscle, workout frequency, and PRs.
 
 ## Unit handling (kg / lb)
 
+> **The kg/lb toggle UI is temporarily hidden.** The `unit` state, storage key
+> (`mgym.unit`), and `toDisplayWeight`/`fromDisplayWeight` conversion all remain
+> in place and default to `"kg"`, so the app currently displays kilograms
+> everywhere. The control (a row in the **More** tab) is commented out pending the
+> bodyweight-conversion fix below — restore that row to re-enable switching.
+
 **Workout weights are always stored in kilograms.** The `unit` toggle only
 affects display, converted in `src/lib/units.js`:
 
@@ -332,7 +406,9 @@ These reflect the code as it stands; documented here for a future refactor, not
 fixed by this documentation pass.
 
 1. **Bodyweight logs aren't unit-converted** — `weightLogs` store raw numbers;
-   the kg/lb toggle only relabels them.
+   the kg/lb toggle only relabels them. The toggle UI is currently **hidden** (see
+   [Unit handling](#unit-handling-kg--lb)) so the app shows kg only; restore the
+   More-tab Units row once bodyweight conversion is handled.
 2. **Import restores extra fields unvalidated** — `note`/`weightLogs`/
    `weeklyNotes`/`unit`/`tab` bypass `normalizeData`.
 3. **`normalizeWorkout` dead guard** — `if (!date || !normExercises)`;

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -232,7 +232,7 @@ set-by-set, persisted to `mgym.session.v1` so a refresh mid-workout resumes:
 
 ```js
 {
-  (workoutId, startedAt, currentIdx, done);
+  (workoutId, startedAt, currentIdx);
 }
 ```
 
@@ -240,18 +240,23 @@ set-by-set, persisted to `mgym.session.v1` so a refresh mid-workout resumes:
   `workouts`; live edits write through to it).
 - `startedAt` — epoch ms, for the elapsed clock.
 - `currentIdx` — index of the exercise on screen.
-- `done` — a **flat map** of completed sets keyed `"exerciseIdx:setIdx"` → `true`.
-  This is transient session state; it is **not** stored on the `Set` itself.
+
+There is **no separate done flag**: a set counts as logged once it has reps
+entered (`reps > 0`), so completion lives on the set itself and rides along when
+exercises are reordered. Newly added sets/exercises start with `reps: 0` (the
+weight prefills as a convenience); each exercise also has its own RPE + feedback
+(reusing `RpeFeedback`).
 
 When `session` is non-null, `App` renders `LiveSession` full-screen instead of the
-tabbed layout. Pure helpers (`setKey`, `toggleDone`, `doneCount`, `totalSets`,
-`formatClock`) live in `src/lib/liveSession.js`. Exercises can be **reordered**
-mid-session (machines get taken); since the `done` map is keyed by exercise
-index, `remapDoneAfterMove` / `remapIndexAfterMove` shift those keys (and the
-on-screen pointer) to follow a `moveItem` reorder. Entry points: **Home**'s today
-card and each **WorkoutHistoryItem** ("▶ Start") call `startSession`; **Home** and
-the **Workouts** tab offer "Start empty workout" (`startEmptyWorkout`). `Finish`
-calls `endSession`, and drops the workout if it was left with zero exercises.
+tabbed layout. Pure helpers (`isLogged`, `completedSets`, `totalSets`,
+`remapIndexAfterMove`, `formatClock`) live in `src/lib/liveSession.js`. Exercises
+can be **reordered** mid-session (machines get taken) by dragging the chips
+(pointer-based, touch + mouse) or the per-exercise up/down buttons; only the
+on-screen pointer needs `remapIndexAfterMove` to stay on the same exercise.
+Entry points: **Home**'s today card and each **WorkoutHistoryItem** ("▶ Start")
+call `startSession`; **Home** and the **Workouts** tab offer "Start empty workout"
+(`startEmptyWorkout`). `Finish` calls `endSession`, and drops the workout if it
+was left with zero exercises.
 
 ## Data model
 

--- a/docs/DATA-MODEL.md
+++ b/docs/DATA-MODEL.md
@@ -132,8 +132,7 @@ workout (which lives in `workouts`) and tracks transient logging UI state.
 {
   "workoutId": "…",
   "startedAt": 1718275200000,
-  "currentIdx": 0,
-  "done": { "0:0": true, "0:1": true }
+  "currentIdx": 0
 }
 ```
 
@@ -142,11 +141,12 @@ workout (which lives in `workouts`) and tracks transient logging UI state.
 | `workoutId`  | `string` | `Workout.id` being logged; live edits write through to it.  |
 | `startedAt`  | `number` | Epoch ms when the session began (drives the elapsed clock). |
 | `currentIdx` | `number` | Index of the exercise currently on screen.                  |
-| `done`       | `object` | Completed-set map keyed `"exerciseIdx:setIdx"` → `true`.    |
 
-The `done` flags are **session-only** — they are not written onto `Set` objects,
-so finishing a session leaves the workout as ordinary logged data. Helpers in
-`src/lib/liveSession.js`. Not included in backups.
+There is **no done-flag map**: a set is treated as logged once it has `reps > 0`,
+so completion lives on the `Set` itself (and follows it when exercises are
+reordered). The session only tracks which workout, when it started, and which
+exercise is on screen. Helpers in `src/lib/liveSession.js`. Not included in
+backups.
 
 ### Bodyweight log (`weightLogs`)
 

--- a/docs/DATA-MODEL.md
+++ b/docs/DATA-MODEL.md
@@ -10,16 +10,18 @@ versioned, and that is the only versioning.
 
 ## localStorage keys
 
-| Key                        | Written by              | Holds                                   | Default when absent                              |
-| -------------------------- | ----------------------- | --------------------------------------- | ------------------------------------------------ |
-| `mgym.exercises.v1`        | `AppContext` (`K_EX`)   | `Exercise[]`                            | the 76-entry seed `src/data/exercises_seed.json` |
-| `mgym.workouts.v1`         | `AppContext` (`K_WO`)   | `Workout[]`                             | `[]`                                             |
-| `mgym.unit`                | `AppContext` (`K_UNIT`) | `"kg"` \| `"lb"`                        | `"kg"`                                           |
-| `mgym.tab`                 | `AppContext` (`K_TAB`)  | active tab string                       | `"workouts"`                                     |
-| `mgym.note.v1`             | `Notepad` (`K_NOTE`)    | `string` — global note                  | `""`                                             |
-| `weightLogs`               | `WeightTracker`         | `{ [YYYY-MM-DD]: number }` — bodyweight | `{}`                                             |
-| `weekly-note:<weekKey>`    | `WeeklyNotes`           | `string` — one note per ISO week        | `""`                                             |
-| `summary-open:<periodKey>` | `PeriodCard`            | `boolean` — card collapse state         | card default                                     |
+| Key                        | Written by                 | Holds                                                                                | Default when absent                              |
+| -------------------------- | -------------------------- | ------------------------------------------------------------------------------------ | ------------------------------------------------ |
+| `mgym.exercises.v1`        | `AppContext` (`K_EX`)      | `Exercise[]`                                                                         | the 76-entry seed `src/data/exercises_seed.json` |
+| `mgym.workouts.v1`         | `AppContext` (`K_WO`)      | `Workout[]`                                                                          | `[]`                                             |
+| `mgym.unit`                | `AppContext` (`K_UNIT`)    | `"kg"` \| `"lb"` (toggle UI hidden; effectively `"kg"`)                              | `"kg"`                                           |
+| `mgym.tab`                 | `AppContext` (`K_TAB`)     | active tab: `home`/`workouts`/`progress`/`exercises`/`more` (legacy values remapped) | `"workouts"`                                     |
+| `mgym.theme`               | `AppContext` (`K_THEME`)   | `"system"` \| `"light"` \| `"dark"`                                                  | `"system"`                                       |
+| `mgym.session.v1`          | `AppContext` (`K_SESSION`) | live-logging session object, or `null`                                               | `null`                                           |
+| `mgym.note.v1`             | `Notepad` (`K_NOTE`)       | `string` — global note                                                               | `""`                                             |
+| `weightLogs`               | `WeightTracker`            | `{ [YYYY-MM-DD]: number }` — bodyweight                                              | `{}`                                             |
+| `weekly-note:<weekKey>`    | `WeeklyNotes`              | `string` — one note per ISO week                                                     | `""`                                             |
+| `summary-open:<periodKey>` | `PeriodCard`               | `boolean` — card collapse state                                                      | card default                                     |
 
 All values are stored with `JSON.stringify`. String values (the notes) are
 stored as JSON strings (e.g. the literal `""`).
@@ -72,8 +74,10 @@ One training session on a given date.
 | `name`      | `string`                | Display name; falls back to the date when left blank.                                                                   | the `date` |
 | `exercises` | `WorkoutExercise[]`     | Exercises performed (user-controlled order).                                                                            | `[]`       |
 
-A workout may have an empty `exercises` array — the Calendar tab can create an
-empty workout for a day before exercises are added.
+A workout may have an empty `exercises` array — the Calendar view can create an
+empty workout for a day, and "Start empty workout" creates one to log into. An
+empty workout left after a live session is finished is discarded (see
+[Live session](#live-session-mgymsessionv1)).
 
 ### WorkoutExercise
 
@@ -83,7 +87,7 @@ from `Exercise`.
 | Field          | Type             | Purpose                                                 | Default                         |
 | -------------- | ---------------- | ------------------------------------------------------- | ------------------------------- |
 | `exerciseName` | `string`         | Reference to an `Exercise` by its `name` (not an id).   | required                        |
-| `sets`         | `Set[]`          | Sets performed; 1–5 entries.                            | `[{ set:1, weight:0, reps:0 }]` |
+| `sets`         | `Set[]`          | Sets performed; 1–`MAX_SETS` (10) entries.              | `[{ set:1, weight:0, reps:0 }]` |
 | `rpe`          | `number \| null` | Optional rate of perceived exertion, 6–10 in 0.5 steps. | `null`                          |
 | `feedback`     | `string`         | Optional free-text note reviewing the exercise.         | `""`                            |
 
@@ -119,6 +123,31 @@ Constraints enforced in code:
   `toDisplayWeight`/`fromDisplayWeight` (`src/lib/units.js`). See
   [ARCHITECTURE.md → Unit handling](../ARCHITECTURE.md#unit-handling-kg--lb).
 
+### Live session (`mgym.session.v1`)
+
+The in-progress live-logging session, or `null` when not logging. It points at a
+workout (which lives in `workouts`) and tracks transient logging UI state.
+
+```json
+{
+  "workoutId": "…",
+  "startedAt": 1718275200000,
+  "currentIdx": 0,
+  "done": { "0:0": true, "0:1": true }
+}
+```
+
+| Field        | Type     | Purpose                                                     |
+| ------------ | -------- | ----------------------------------------------------------- |
+| `workoutId`  | `string` | `Workout.id` being logged; live edits write through to it.  |
+| `startedAt`  | `number` | Epoch ms when the session began (drives the elapsed clock). |
+| `currentIdx` | `number` | Index of the exercise currently on screen.                  |
+| `done`       | `object` | Completed-set map keyed `"exerciseIdx:setIdx"` → `true`.    |
+
+The `done` flags are **session-only** — they are not written onto `Set` objects,
+so finishing a session leaves the workout as ordinary logged data. Helpers in
+`src/lib/liveSession.js`. Not included in backups.
+
 ### Bodyweight log (`weightLogs`)
 
 A flat map used by the Weight tab:
@@ -133,8 +162,10 @@ A flat map used by the Weight tab:
 | value | `number`                | Bodyweight as entered. |
 
 > **Not unit-converted.** Unlike workout `weight`, these are the raw numbers the
-> user typed; the kg/lb toggle only relabels them. Weekly averages and the
-> Summary "Avg Weight" KPI are computed directly from these numbers.
+> user typed; the kg/lb toggle only relabels them. Because that mislabels
+> bodyweight in lb, the **toggle UI is currently hidden** and the app shows kg
+> only. Weekly averages and the Progress "Avg Weight" KPI are computed directly
+> from these numbers.
 
 ### Notes
 
@@ -188,6 +219,9 @@ On import, exercises/workouts go through `normalizeData()` then **merge** or
 **replace** (rules in
 [ARCHITECTURE.md → Export / import](../ARCHITECTURE.md#export--import-backup));
 the remaining fields are written straight back to their keys.
+
+The `mgym.theme` preference and the `mgym.session.v1` live session are **not**
+part of the backup payload — they are device-local UI state.
 
 ## Worth knowing before building on this
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,111 +1,44 @@
 import React from "react";
 import "./index.css";
 import { AppProvider, useApp } from "./context/AppContext";
-import { Button } from "./components/ui/Button";
-import DataManagementMenu from "./components/DataManagementMenu";
-import WorkoutPlanner from "./components/WorkoutPlanner";
-import WorkoutHistory from "./components/WorkoutHistory";
+import BottomNav from "./components/ui/BottomNav";
+import Home from "./components/Home";
+import WorkoutsTab from "./components/WorkoutsTab";
+import Progress from "./components/Progress";
 import ExerciseManager from "./components/ExerciseManager";
-import CalendarView from "./components/CalendarView";
-import Notepad from "./components/Notepad";
-import DashboardSummary from "./components/DashboardSummary";
-import WeightTracker from "./components/WeightTracker";
+import MoreMenu from "./components/MoreMenu";
 
-/**
- * Internal component that consumes AppContext and renders the app UI.
- * This separates context consumption from the outer provider.
- */
+// The five primary destinations rendered by the bottom nav.
+const VIEWS = {
+  home: Home,
+  workouts: WorkoutsTab,
+  progress: Progress,
+  exercises: ExerciseManager,
+  more: MoreMenu,
+};
+
+// Map legacy persisted tab values (the old six-tab IA) onto the new destinations
+// so returning users don't land on a blank screen.
+const LEGACY = {
+  calendar: "workouts",
+  weight: "progress",
+  summary: "progress",
+  notepad: "more",
+};
+
 function AppContent() {
-  const { tab, setTab, unit, setUnit } = useApp();
+  const { tab, setTab } = useApp();
+  const active = VIEWS[tab] ? tab : LEGACY[tab] || "home";
+  const View = VIEWS[active];
 
   return (
-    <div className="max-w-3xl mx-auto p-4 space-y-4">
-      {/* Header */}
-      <div className="flex items-center justify-between gap-2">
-        <h1 className="text-2xl font-bold">Gym&nbsp;Tracker</h1>
-        <div className="flex items-center gap-4">
-          <DataManagementMenu />
-          <Button
-            variant="secondary"
-            onClick={() => setUnit((u) => (u === "kg" ? "lb" : "kg"))}
-          >
-            Unit: {unit.toUpperCase()}
-          </Button>
-        </div>
-      </div>
-
-      {/* Tab navigation (scrollable) */}
-      <div className="overflow-x-auto whitespace-nowrap border-b pb-2">
-        <div className="inline-flex gap-2">
-          <Button
-            variant={tab === "workouts" ? "primary" : "ghost"}
-            onClick={() => setTab("workouts")}
-          >
-            Workouts
-          </Button>
-          <Button
-            variant={tab === "calendar" ? "primary" : "ghost"}
-            onClick={() => setTab("calendar")}
-          >
-            Calendar
-          </Button>
-          <Button
-            variant={tab === "exercises" ? "primary" : "ghost"}
-            onClick={() => setTab("exercises")}
-          >
-            Exercises
-          </Button>
-          <Button
-            variant={tab === "weight" ? "primary" : "ghost"}
-            onClick={() => setTab("weight")}
-          >
-            Weight
-          </Button>
-          <Button
-            variant={tab === "notepad" ? "primary" : "ghost"}
-            onClick={() => setTab("notepad")}
-          >
-            Notepad
-          </Button>
-          <Button
-            variant={tab === "summary" ? "primary" : "ghost"}
-            onClick={() => setTab("summary")}
-          >
-            Summary
-          </Button>
-        </div>
-      </div>
-
-      {/* Main content */}
-      {tab === "workouts" && (
-        <>
-          <WorkoutPlanner />
-          <WorkoutHistory />
-        </>
-      )}
-
-      {tab === "calendar" && <CalendarView />}
-
-      {tab === "exercises" && <ExerciseManager />}
-
-      {tab === "notepad" && <Notepad />}
-
-      {tab === "summary" && <DashboardSummary />}
-
-      {tab === "weight" && <WeightTracker />}
-
-      {/* Footer */}
-      <p className="text-center text-xs text-neutral-500">
-        Data stored in your browser
-      </p>
+    <div className="mx-auto min-h-full max-w-3xl px-4 pb-24 pt-5">
+      <View />
+      <BottomNav active={active} onSelect={setTab} />
     </div>
   );
 }
 
-/**
- * Top-level component wraps the application in AppProvider
- * so all children can access the shared state.
- */
 export default function App() {
   return (
     <AppProvider>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,6 +7,7 @@ import WorkoutsTab from "./components/WorkoutsTab";
 import Progress from "./components/Progress";
 import ExerciseManager from "./components/ExerciseManager";
 import MoreMenu from "./components/MoreMenu";
+import LiveSession from "./components/LiveSession";
 
 // The five primary destinations rendered by the bottom nav.
 const VIEWS = {
@@ -27,9 +28,12 @@ const LEGACY = {
 };
 
 function AppContent() {
-  const { tab, setTab } = useApp();
+  const { tab, setTab, session } = useApp();
   const active = VIEWS[tab] ? tab : LEGACY[tab] || "home";
   const View = VIEWS[active];
+
+  // A live-logging session takes over the whole screen.
+  if (session) return <LiveSession />;
 
   return (
     <div className="mx-auto min-h-full max-w-3xl px-4 pb-24 pt-5">

--- a/src/components/AddExerciseInput.jsx
+++ b/src/components/AddExerciseInput.jsx
@@ -75,19 +75,19 @@ export default function AddExerciseInput({ allExercises, onAdd }) {
         </Button>
       </div>
       {open && options.length > 0 && (
-        <div className="absolute z-20 mt-1 w-full overflow-hidden rounded-xl border bg-white shadow">
+        <div className="absolute z-20 mt-1 w-full overflow-hidden rounded-xl border dark:border-neutral-800 bg-white dark:bg-neutral-900 shadow">
           {options.map((o, i) => (
             <button
               key={(o.name || "") + i}
               onClick={() => choose(o)}
-              className="flex w-full items-center justify-between px-3 py-2 text-left text-sm hover:bg-neutral-50"
+              className="flex w-full items-center justify-between px-3 py-2 text-left text-sm hover:bg-neutral-50 dark:hover:bg-neutral-800"
             >
               <span className="flex flex-col">
                 <span className="font-medium">
                   {o._isNew ? `${o.name} (new)` : o.name}
                 </span>
                 {!o._isNew && (
-                  <span className="text-xs text-neutral-600">
+                  <span className="text-xs text-neutral-600 dark:text-neutral-300">
                     {o.type || "—"} • {o.equipment || "—"} •{" "}
                     {o.mainMuscle || "—"}
                   </span>

--- a/src/components/CalendarView.jsx
+++ b/src/components/CalendarView.jsx
@@ -75,7 +75,7 @@ export default function CalendarView() {
               Next ›
             </Button>
           </div>
-          <div className="grid grid-cols-7 text-xs text-neutral-600 mb-1">
+          <div className="grid grid-cols-7 text-xs text-neutral-600 dark:text-neutral-300 mb-1">
             {["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"].map((d) => (
               <div key={d} className="py-1 text-center">
                 {d}
@@ -89,7 +89,7 @@ export default function CalendarView() {
               return (
                 <button
                   key={idx}
-                  className={`aspect-square rounded-xl border text-sm flex flex-col items-center justify-center ${isSelected ? "bg-blue-600 text-white" : "bg-white"}`}
+                  className={`aspect-square rounded-xl border dark:border-neutral-800 text-sm flex flex-col items-center justify-center ${isSelected ? "bg-blue-600 text-white" : "bg-white dark:bg-neutral-900"}`}
                   onClick={() => ds && setSelected(ds)}
                   disabled={!ds}
                 >
@@ -98,7 +98,7 @@ export default function CalendarView() {
                   </span>
                   {count > 0 && (
                     <span
-                      className={`mt-1 text-[10px] ${isSelected ? "text-white" : "text-neutral-600"}`}
+                      className={`mt-1 text-[10px] ${isSelected ? "text-white" : "text-neutral-600 dark:text-neutral-300"}`}
                     >
                       {count} workout{count > 1 ? "s" : ""}
                     </span>
@@ -118,11 +118,16 @@ export default function CalendarView() {
             </Button>
           </div>
           {selectedWorkouts.length === 0 && (
-            <p className="text-sm text-neutral-500">No workouts on this day.</p>
+            <p className="text-sm text-neutral-500 dark:text-neutral-400">
+              No workouts on this day.
+            </p>
           )}
           <div className="space-y-3">
             {selectedWorkouts.map((w) => (
-              <div key={w.id} className="rounded-xl border p-3">
+              <div
+                key={w.id}
+                className="rounded-xl border dark:border-neutral-800 p-3"
+              >
                 <div className="mb-2 flex items-center justify-between">
                   <div className="font-medium">{w.name}</div>
                   <div className="flex items-center gap-2">
@@ -144,13 +149,15 @@ export default function CalendarView() {
                   </div>
                 </div>
                 {w.exercises.length === 0 ? (
-                  <p className="text-sm text-neutral-500">No exercises yet.</p>
+                  <p className="text-sm text-neutral-500 dark:text-neutral-400">
+                    No exercises yet.
+                  </p>
                 ) : (
                   <div className="grid gap-2">
                     {w.exercises.map((we, i) => (
                       <div
                         key={i}
-                        className="rounded-lg border px-3 py-2 text-sm"
+                        className="rounded-lg border dark:border-neutral-800 px-3 py-2 text-sm"
                       >
                         <div className="font-medium">
                           {we.exerciseName}
@@ -159,7 +166,7 @@ export default function CalendarView() {
                               exercises.find((e) => e.name === we.exerciseName)
                                 ?.recommendRep || "";
                             return rec ? (
-                              <span className="ml-2 text-xs text-neutral-500">
+                              <span className="ml-2 text-xs text-neutral-500 dark:text-neutral-400">
                                 ({rec})
                               </span>
                             ) : null;
@@ -177,7 +184,7 @@ export default function CalendarView() {
                     ))}
                   </div>
                 )}
-                <div className="rounded-xl border p-3 mt-2">
+                <div className="rounded-xl border dark:border-neutral-800 p-3 mt-2">
                   <div className="mb-2 font-medium text-sm">Add exercise</div>
                   <AddExerciseInput
                     allExercises={exercises}

--- a/src/components/ConfirmDialog.jsx
+++ b/src/components/ConfirmDialog.jsx
@@ -53,7 +53,7 @@ export function ConfirmProvider({ children }) {
         <div className="fixed inset-0 z-[9999]">
           <div className="absolute inset-0 bg-black/50" onClick={onCancel} />
           <div className="absolute inset-0 flex items-center justify-center p-4">
-            <div className="w-full max-w-md overflow-hidden rounded-2xl border bg-white shadow-xl">
+            <div className="w-full max-w-md overflow-hidden rounded-2xl border dark:border-neutral-800 bg-white dark:bg-neutral-900 shadow-xl">
               {/* Header */}
               <div className="flex items-center gap-3 bg-blue-50 px-5 py-4">
                 <div className="h-7 w-7 rounded-full bg-blue-600" />
@@ -62,14 +62,14 @@ export function ConfirmProvider({ children }) {
                 </div>
               </div>
               {/* Body */}
-              <div className="px-5 py-4 text-sm text-neutral-700 whitespace-pre-line">
+              <div className="px-5 py-4 text-sm text-neutral-700 dark:text-neutral-300 whitespace-pre-line">
                 {state.message || "This action cannot be undone."}
               </div>
               {/* Footer */}
               <div className="flex justify-end gap-2 px-5 py-4">
                 <button
                   onClick={onCancel}
-                  className="inline-flex items-center justify-center rounded-xl border border-neutral-300 bg-white px-3 py-1.5 text-sm hover:bg-neutral-50"
+                  className="inline-flex items-center justify-center rounded-xl border dark:border-neutral-800 border-neutral-300 dark:border-neutral-700 bg-white dark:bg-neutral-900 px-3 py-1.5 text-sm hover:bg-neutral-50 dark:hover:bg-neutral-800"
                 >
                   {state.cancelText || "Cancel"}
                 </button>

--- a/src/components/DashboardSummary.jsx
+++ b/src/components/DashboardSummary.jsx
@@ -116,7 +116,9 @@ export default function DashboardSummary() {
             ),
           )
         ) : (
-          <div className="text-sm text-neutral-500">No weekly data yet.</div>
+          <div className="text-sm text-neutral-500 dark:text-neutral-400">
+            No weekly data yet.
+          </div>
         )
       ) : monthData.length ? (
         monthData.map(({ period, metrics, prevMetrics }) => (
@@ -130,7 +132,9 @@ export default function DashboardSummary() {
           />
         ))
       ) : (
-        <div className="text-sm text-neutral-500">No monthly data yet.</div>
+        <div className="text-sm text-neutral-500 dark:text-neutral-400">
+          No monthly data yet.
+        </div>
       )}
     </div>
   );

--- a/src/components/DataManagementMenu.jsx
+++ b/src/components/DataManagementMenu.jsx
@@ -121,7 +121,7 @@ export default function DataManagementMenu() {
         onChange={onFileChange}
       />
       {open && (
-        <div className="absolute right-0 mt-2 w-48 bg-white border rounded shadow z-10">
+        <div className="absolute right-0 mt-2 w-48 bg-white dark:bg-neutral-900 border dark:border-neutral-800 rounded shadow z-10">
           <Button
             variant="ghost"
             className="w-full justify-start px-4 py-2"

--- a/src/components/Delta.jsx
+++ b/src/components/Delta.jsx
@@ -6,7 +6,9 @@ import React from "react";
 export default function Delta({ curr, prev, decimals = 0 }) {
   if (prev == null || curr == null) {
     return (
-      <span className="text-xs text-neutral-500 ml-1 block sm:inline">—</span>
+      <span className="text-xs text-neutral-500 dark:text-neutral-400 ml-1 block sm:inline">
+        —
+      </span>
     );
   }
   const factor = Math.pow(10, decimals);
@@ -14,7 +16,9 @@ export default function Delta({ curr, prev, decimals = 0 }) {
   const diff = Math.round(diffRaw * factor) / factor;
   if (diff === 0) {
     return (
-      <span className="text-xs text-neutral-500 ml-1 block sm:inline">±0</span>
+      <span className="text-xs text-neutral-500 dark:text-neutral-400 ml-1 block sm:inline">
+        ±0
+      </span>
     );
   }
   const sign = diff > 0 ? "+" : "";

--- a/src/components/ExerciseHistoryModal.jsx
+++ b/src/components/ExerciseHistoryModal.jsx
@@ -31,12 +31,12 @@ export default function ExerciseHistoryModal({
 
   return (
     <div className="fixed inset-0 z-50 bg-black/50 flex items-center justify-center p-4">
-      <div className="bg-white max-w-lg w-full rounded-xl shadow-lg p-4 overflow-y-auto max-h-[80vh]">
+      <div className="bg-white dark:bg-neutral-900 max-w-lg w-full rounded-xl shadow-lg p-4 overflow-y-auto max-h-[80vh]">
         {/* Header */}
         <div className="flex items-center justify-between mb-4">
           <div>
             <div className="text-lg font-medium">{exerciseName}</div>
-            <div className="text-sm text-neutral-500">
+            <div className="text-sm text-neutral-500 dark:text-neutral-400">
               Past workouts containing this exercise
             </div>
           </div>
@@ -48,7 +48,9 @@ export default function ExerciseHistoryModal({
         {/* Body */}
         <div className="space-y-3">
           {filtered.length === 0 && (
-            <p className="text-sm text-neutral-500">No past workouts.</p>
+            <p className="text-sm text-neutral-500 dark:text-neutral-400">
+              No past workouts.
+            </p>
           )}
           {filtered.map((w) => {
             const item = (w.exercises || []).find(
@@ -56,7 +58,10 @@ export default function ExerciseHistoryModal({
             );
             if (!item) return null;
             return (
-              <div key={w.id} className="border rounded-lg p-3 space-y-1">
+              <div
+                key={w.id}
+                className="border dark:border-neutral-800 rounded-lg p-3 space-y-1"
+              >
                 {/* Date and workout name */}
                 <div className="flex items-center gap-2">
                   <Badge>

--- a/src/components/ExerciseManager.jsx
+++ b/src/components/ExerciseManager.jsx
@@ -70,7 +70,7 @@ export default function ExerciseManager() {
           />
           <div className="grid gap-3 mt-4">
             {filtered.length === 0 && (
-              <p className="text-sm text-neutral-500">
+              <p className="text-sm text-neutral-500 dark:text-neutral-400">
                 No exercises yet. Add one to get started.
               </p>
             )}

--- a/src/components/ExerciseManager.jsx
+++ b/src/components/ExerciseManager.jsx
@@ -1,5 +1,4 @@
 import React, { useMemo, useState } from "react";
-import { Card, CardContent } from "./ui/Card";
 import { Input } from "./ui/Input";
 import { useApp } from "../context/AppContext";
 import { extractExerciseOptions } from "../lib/exerciseUtils";
@@ -7,23 +6,36 @@ import NewExerciseInline from "./NewExerciseInline";
 import ExerciseRow from "./ExerciseRow";
 import ExerciseHistoryModal from "./ExerciseHistoryModal";
 
+/** Distinct, sorted mainMuscle values present in the library (non-empty). */
+function muscleGroups(exercises) {
+  const set = new Set();
+  for (const e of exercises) {
+    const m = e.mainMuscle?.trim();
+    if (m) set.add(m);
+  }
+  return [...set].sort((a, b) => a.localeCompare(b));
+}
+
 /**
- * Top-level component for managing exercises. Provides search, creation
- * and editing capabilities. A modal popup is used to display a full
- * history of any exercise across all recorded workouts.
+ * Top-level component for managing exercises. Provides search, muscle-group
+ * filtering, creation and editing. A modal popup displays a full history of any
+ * exercise across all recorded workouts.
  */
 export default function ExerciseManager() {
   const { exercises, setExercises, workouts, unit } = useApp();
   const [query, setQuery] = useState("");
-  // Holds the name of the exercise whose history is being viewed.
+  const [muscle, setMuscle] = useState("all");
+  const [showCreate, setShowCreate] = useState(false);
   const [historyExercise, setHistoryExercise] = useState(null);
 
   const options = useMemo(() => extractExerciseOptions(exercises), [exercises]);
+  const groups = useMemo(() => muscleGroups(exercises), [exercises]);
 
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase();
-    if (!q) return exercises;
     return exercises.filter((e) => {
+      if (muscle !== "all" && e.mainMuscle?.trim() !== muscle) return false;
+      if (!q) return true;
       const hay = [
         e.name,
         e.mainMuscle,
@@ -37,9 +49,12 @@ export default function ExerciseManager() {
         .toLowerCase();
       return hay.includes(q);
     });
-  }, [exercises, query]);
+  }, [exercises, query, muscle]);
 
-  const onCreate = (ex) => setExercises((prev) => [...prev, ex]);
+  const onCreate = (ex) => {
+    setExercises((prev) => [...prev, ex]);
+    setShowCreate(false);
+  };
   const onDelete = (name) =>
     setExercises((prev) => prev.filter((e) => e.name !== name));
   const onUpdate = (name, patch) =>
@@ -47,48 +62,93 @@ export default function ExerciseManager() {
       prev.map((e) => (e.name === name ? { ...e, ...patch, name: e.name } : e)),
     );
 
-  // Callback to open the history modal for a specific exercise
-  const onViewHistory = (exerciseName) => {
-    setHistoryExercise(exerciseName);
+  const chip = (key, label) => {
+    const active = muscle === key;
+    return (
+      <button
+        key={key}
+        type="button"
+        onClick={() => setMuscle(key)}
+        aria-pressed={active}
+        className={[
+          "whitespace-nowrap rounded-full px-3 py-1 text-xs transition",
+          active
+            ? "bg-blue-600 text-white"
+            : "border bg-white text-neutral-600 hover:bg-neutral-50 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-300 dark:hover:bg-neutral-800",
+        ].join(" ")}
+      >
+        {label}
+      </button>
+    );
   };
 
   return (
     <div className="space-y-4">
-      <Card>
-        <CardContent>
-          <div className="flex items-center gap-2 mb-3">
-            <Input
-              placeholder="Search (name, type, muscles, equipment, force)"
-              value={query}
-              onChange={(e) => setQuery(e.target.value)}
-            />
-          </div>
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <h1 className="text-xl font-semibold text-neutral-900 dark:text-neutral-100">
+          Exercises
+          <span className="ml-2 text-sm font-normal text-neutral-400 dark:text-neutral-500">
+            {exercises.length}
+          </span>
+        </h1>
+        <button
+          type="button"
+          onClick={() => setShowCreate((v) => !v)}
+          aria-expanded={showCreate}
+          className="flex h-9 w-9 items-center justify-center rounded-full bg-blue-600 text-lg text-white transition hover:bg-blue-700"
+          aria-label="New exercise"
+        >
+          {showCreate ? "×" : "+"}
+        </button>
+      </div>
+
+      {/* Search */}
+      <Input
+        placeholder="Search (name, type, muscles, equipment, force)"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+      />
+
+      {/* Muscle-group filter chips */}
+      {groups.length > 0 && (
+        <div className="flex gap-2 overflow-x-auto pb-1">
+          {chip("all", "All")}
+          {groups.map((m) => chip(m, m))}
+        </div>
+      )}
+
+      {/* Collapsible create form */}
+      {showCreate && (
+        <div className="rounded-2xl border bg-white p-4 dark:border-neutral-800 dark:bg-neutral-900">
           <NewExerciseInline
             existing={exercises}
             options={options}
             onCreate={onCreate}
           />
-          <div className="grid gap-3 mt-4">
-            {filtered.length === 0 && (
-              <p className="text-sm text-neutral-500 dark:text-neutral-400">
-                No exercises yet. Add one to get started.
-              </p>
-            )}
-            {filtered.map((e) => (
-              <ExerciseRow
-                key={e.name}
-                ex={e}
-                onDelete={onDelete}
-                onUpdate={onUpdate}
-                workouts={workouts}
-                unit={unit}
-                options={options}
-                onViewHistory={onViewHistory}
-              />
-            ))}
-          </div>
-        </CardContent>
-      </Card>
+        </div>
+      )}
+
+      {/* Exercise list */}
+      <div className="grid gap-3">
+        {filtered.length === 0 && (
+          <p className="text-sm text-neutral-500 dark:text-neutral-400">
+            No exercises match. Try a different search or filter.
+          </p>
+        )}
+        {filtered.map((e) => (
+          <ExerciseRow
+            key={e.name}
+            ex={e}
+            onDelete={onDelete}
+            onUpdate={onUpdate}
+            workouts={workouts}
+            unit={unit}
+            options={options}
+            onViewHistory={setHistoryExercise}
+          />
+        ))}
+      </div>
 
       {/* Modal popup for viewing exercise history across past workouts */}
       <ExerciseHistoryModal

--- a/src/components/ExerciseManager.test.jsx
+++ b/src/components/ExerciseManager.test.jsx
@@ -1,0 +1,57 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { AppProvider } from "../context/AppContext";
+import { ConfirmProvider } from "./ConfirmDialog";
+import { saveLS, K_EX } from "../lib/storage";
+import ExerciseManager from "./ExerciseManager";
+
+function seedAndRender() {
+  saveLS(K_EX, [
+    { name: "Bench Press", mainMuscle: "Chest" },
+    { name: "Back Squat", mainMuscle: "Legs" },
+  ]);
+  return render(
+    <ConfirmProvider>
+      <AppProvider>
+        <ExerciseManager />
+      </AppProvider>
+    </ConfirmProvider>,
+  );
+}
+
+describe("ExerciseManager", () => {
+  it("shows the header with a count and lists exercises", () => {
+    seedAndRender();
+    expect(
+      screen.getByRole("heading", { name: /Exercises/ }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Bench Press")).toBeInTheDocument();
+    expect(screen.getByText("Back Squat")).toBeInTheDocument();
+  });
+
+  it("filters by muscle-group chip", async () => {
+    const user = userEvent.setup();
+    seedAndRender();
+    await user.click(screen.getByRole("button", { name: "Legs" }));
+    expect(screen.getByText("Back Squat")).toBeInTheDocument();
+    expect(screen.queryByText("Bench Press")).not.toBeInTheDocument();
+  });
+
+  it("filters by search query", async () => {
+    const user = userEvent.setup();
+    seedAndRender();
+    await user.type(screen.getByPlaceholderText(/Search/), "bench");
+    expect(screen.getByText("Bench Press")).toBeInTheDocument();
+    expect(screen.queryByText("Back Squat")).not.toBeInTheDocument();
+  });
+
+  it("toggles the create form via the New button", async () => {
+    const user = userEvent.setup();
+    seedAndRender();
+    const newBtn = screen.getByRole("button", { name: "New exercise" });
+    expect(newBtn).toHaveTextContent("+");
+    await user.click(newBtn);
+    expect(newBtn).toHaveTextContent("×");
+  });
+});

--- a/src/components/ExerciseRow.jsx
+++ b/src/components/ExerciseRow.jsx
@@ -49,24 +49,24 @@ export default function ExerciseRow({
   );
 
   return (
-    <div className="rounded-2xl border p-3 space-y-2">
+    <div className="rounded-2xl border dark:border-neutral-800 p-3 space-y-2">
       <div className="flex items-start justify-between gap-4">
         <div>
           <h4 className="text-base font-semibold">
             {ex.name}
             {ex.recommendRep ? (
-              <span className="ml-2 text-xs text-neutral-500">
+              <span className="ml-2 text-xs text-neutral-500 dark:text-neutral-400">
                 ({ex.recommendRep})
               </span>
             ) : null}
             {usedCount > 0 && (
-              <span className="ml-2 text-xs text-neutral-500">
+              <span className="ml-2 text-xs text-neutral-500 dark:text-neutral-400">
                 {usedCount} workout
                 {usedCount > 1 ? "s" : ""}
               </span>
             )}
           </h4>
-          <div className="mt-1 text-sm text-neutral-600 space-x-2">
+          <div className="mt-1 text-sm text-neutral-600 dark:text-neutral-300 space-x-2">
             {ex.type && <span>{ex.type}</span>}
             {ex.equipment && <span>{ex.equipment}</span>}
             {ex.mainMuscle && <span>Main: {ex.mainMuscle}</span>}
@@ -177,7 +177,9 @@ export default function ExerciseRow({
 
       {/* Last workout summary */}
       <div className="mt-2">
-        <p className="text-xs font-medium text-neutral-500">Last workout</p>
+        <p className="text-xs font-medium text-neutral-500 dark:text-neutral-400">
+          Last workout
+        </p>
         {ex.lastWorkout ? (
           <div className="mt-1 flex flex-wrap items-center gap-2 text-sm">
             <Badge>
@@ -193,7 +195,7 @@ export default function ExerciseRow({
             </div>
           </div>
         ) : (
-          <p className="text-sm text-neutral-400">—</p>
+          <p className="text-sm text-neutral-400 dark:text-neutral-500">—</p>
         )}
       </div>
 

--- a/src/components/GroupedMuscleBar.jsx
+++ b/src/components/GroupedMuscleBar.jsx
@@ -13,7 +13,7 @@ export default function GroupedMuscleBar({ current, previous }) {
 
   if (!muscles.size) {
     return (
-      <div className="text-sm text-neutral-500">
+      <div className="text-sm text-neutral-500 dark:text-neutral-400">
         No data logged this period.
       </div>
     );
@@ -87,7 +87,7 @@ export default function GroupedMuscleBar({ current, previous }) {
           );
         })}
       {/* Legend */}
-      <div className="flex items-center gap-4 text-xs text-neutral-600">
+      <div className="flex items-center gap-4 text-xs text-neutral-600 dark:text-neutral-300">
         <div className="flex items-center gap-1">
           <span className="inline-block h-2 w-3 bg-green-500" /> Sets Now
         </div>

--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -1,0 +1,192 @@
+import React, { useMemo } from "react";
+import { useApp } from "../context/AppContext";
+import { loadLS, K_WEIGHT_LOGS } from "../lib/storage";
+import { ymdFromDate } from "../lib/date";
+import {
+  weekStats,
+  weekVolumeByDay,
+  currentStreak,
+  workoutVolume,
+  latestBodyweight,
+} from "../lib/homeStats";
+
+const DAY_LABELS = ["M", "T", "W", "T", "F", "S", "S"];
+
+function greeting(h = new Date().getHours()) {
+  if (h < 12) return "Good morning";
+  if (h < 18) return "Good afternoon";
+  return "Good evening";
+}
+
+const tonnes = (kg) => `${(kg / 1000).toFixed(1)}t`;
+
+function StatTile({ value, label }) {
+  return (
+    <div className="rounded-xl border bg-white p-3 text-center">
+      <div className="text-lg font-semibold text-neutral-900">{value}</div>
+      <div className="text-[11px] text-neutral-500">{label}</div>
+    </div>
+  );
+}
+
+export default function Home() {
+  const { workouts, setTab, unit } = useApp();
+  // Captured once at mount: a stable "now" keeps the memos below from
+  // recomputing every render (the wall-clock day doesn't change mid-session).
+  const now = useMemo(() => new Date(), []);
+  const todayYmd = ymdFromDate(now);
+
+  const stats = useMemo(() => weekStats(workouts, now), [workouts, now]);
+  const byDay = useMemo(() => weekVolumeByDay(workouts, now), [workouts, now]);
+  const streak = useMemo(() => currentStreak(workouts, now), [workouts, now]);
+  const bodyweight = useMemo(
+    () => latestBodyweight(loadLS(K_WEIGHT_LOGS, {})),
+    [],
+  );
+
+  const todays = (workouts || []).filter((w) => w.date === todayYmd);
+  const recent = useMemo(
+    () =>
+      [...(workouts || [])]
+        .sort((a, b) => b.date.localeCompare(a.date))
+        .slice(0, 3),
+    [workouts],
+  );
+
+  const maxDay = Math.max(1, ...byDay);
+  const todayIdx = (now.getDay() + 6) % 7;
+
+  const dateLabel = now.toLocaleDateString(undefined, {
+    weekday: "long",
+    month: "short",
+    day: "numeric",
+  });
+
+  return (
+    <div className="space-y-4">
+      {/* Greeting + streak */}
+      <div className="flex items-start justify-between">
+        <div>
+          <div className="text-xs text-neutral-500">{dateLabel}</div>
+          <h1 className="text-xl font-semibold text-neutral-900">
+            {greeting()}
+          </h1>
+        </div>
+        {streak > 0 && (
+          <span className="inline-flex items-center gap-1 rounded-full border bg-white px-3 py-1 text-sm">
+            <span aria-hidden>🔥</span>
+            <span className="font-semibold">{streak}</span>
+            <span className="sr-only">day streak</span>
+          </span>
+        )}
+      </div>
+
+      {/* Today's plan */}
+      <div className="rounded-2xl border bg-white p-4">
+        <div className="text-[11px] uppercase tracking-wide text-neutral-500">
+          Today
+        </div>
+        {todays.length ? (
+          <>
+            <div className="mt-0.5 font-semibold text-neutral-900">
+              {todays[0].name?.trim() || "Workout"}
+            </div>
+            <div className="text-xs text-neutral-500">
+              {todays[0].exercises?.length || 0} exercises ·{" "}
+              {Math.round(workoutVolume(todays[0])).toLocaleString()} kg
+            </div>
+            <button
+              type="button"
+              onClick={() => setTab("workouts")}
+              className="mt-3 w-full rounded-xl bg-blue-600 py-2.5 text-sm font-medium text-white transition hover:bg-blue-700"
+            >
+              View workout
+            </button>
+          </>
+        ) : (
+          <>
+            <div className="mt-0.5 font-semibold text-neutral-900">
+              No workout logged yet
+            </div>
+            <div className="text-xs text-neutral-500">
+              Plan today&apos;s session to get started.
+            </div>
+            <button
+              type="button"
+              onClick={() => setTab("workouts")}
+              className="mt-3 w-full rounded-xl bg-blue-600 py-2.5 text-sm font-medium text-white transition hover:bg-blue-700"
+            >
+              Plan a workout
+            </button>
+          </>
+        )}
+      </div>
+
+      {/* Quick stats */}
+      <div className="grid grid-cols-3 gap-2">
+        <StatTile value={stats.count} label="workouts" />
+        <StatTile value={tonnes(stats.volume)} label="volume" />
+        <StatTile
+          value={bodyweight ? bodyweight.value : "—"}
+          label={bodyweight ? unit : "weight"}
+        />
+      </div>
+
+      {/* This week volume bars */}
+      <div className="rounded-2xl border bg-white p-4">
+        <div className="mb-3 text-[11px] uppercase tracking-wide text-neutral-500">
+          This week
+        </div>
+        <div className="flex h-24 items-stretch gap-2">
+          {byDay.map((v, i) => (
+            <div
+              key={i}
+              className="flex h-full flex-1 flex-col items-center gap-1"
+            >
+              <div className="flex w-full flex-1 items-end">
+                <div
+                  className={[
+                    "w-full rounded-md",
+                    i === todayIdx ? "bg-blue-600" : "bg-blue-200",
+                  ].join(" ")}
+                  style={{ height: `${Math.max(4, (v / maxDay) * 100)}%` }}
+                />
+              </div>
+              <span className="text-[10px] text-neutral-400">
+                {DAY_LABELS[i]}
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Recent activity */}
+      {recent.length > 0 && (
+        <div className="space-y-2">
+          <div className="text-[11px] uppercase tracking-wide text-neutral-500">
+            Recent
+          </div>
+          {recent.map((w) => (
+            <button
+              key={w.id}
+              type="button"
+              onClick={() => setTab("workouts")}
+              className="flex w-full items-center justify-between rounded-xl border bg-white p-3 text-left transition hover:bg-neutral-50"
+            >
+              <div>
+                <div className="text-sm font-medium text-neutral-900">
+                  {w.name?.trim() || "Workout"}
+                </div>
+                <div className="text-[11px] text-neutral-500">{w.date}</div>
+              </div>
+              <div className="text-xs text-neutral-500">
+                {w.exercises?.length || 0} ex ·{" "}
+                {Math.round(workoutVolume(w)).toLocaleString()} kg
+              </div>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -34,7 +34,7 @@ function StatTile({ value, label }) {
 }
 
 export default function Home() {
-  const { workouts, setTab, unit } = useApp();
+  const { workouts, setTab, unit, startSession, startEmptyWorkout } = useApp();
   // Captured once at mount: a stable "now" keeps the memos below from
   // recomputing every render (the wall-clock day doesn't change mid-session).
   const now = useMemo(() => new Date(), []);
@@ -103,10 +103,10 @@ export default function Home() {
             </div>
             <button
               type="button"
-              onClick={() => setTab("workouts")}
+              onClick={() => startSession(todays[0].id)}
               className="mt-3 w-full rounded-xl bg-blue-600 py-2.5 text-sm font-medium text-white transition hover:bg-blue-700"
             >
-              View workout
+              Start workout
             </button>
           </>
         ) : (
@@ -117,13 +117,22 @@ export default function Home() {
             <div className="text-xs text-neutral-500 dark:text-neutral-400">
               Plan today&apos;s session to get started.
             </div>
-            <button
-              type="button"
-              onClick={() => setTab("workouts")}
-              className="mt-3 w-full rounded-xl bg-blue-600 py-2.5 text-sm font-medium text-white transition hover:bg-blue-700"
-            >
-              Plan a workout
-            </button>
+            <div className="mt-3 flex gap-2">
+              <button
+                type="button"
+                onClick={startEmptyWorkout}
+                className="flex-1 rounded-xl bg-blue-600 py-2.5 text-sm font-medium text-white transition hover:bg-blue-700"
+              >
+                Start workout
+              </button>
+              <button
+                type="button"
+                onClick={() => setTab("workouts")}
+                className="flex-1 rounded-xl border py-2.5 text-sm font-medium text-neutral-700 transition hover:bg-neutral-50 dark:border-neutral-700 dark:text-neutral-200 dark:hover:bg-neutral-800"
+              >
+                Plan ahead
+              </button>
+            </div>
           </>
         )}
       </div>

--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -22,9 +22,13 @@ const tonnes = (kg) => `${(kg / 1000).toFixed(1)}t`;
 
 function StatTile({ value, label }) {
   return (
-    <div className="rounded-xl border bg-white p-3 text-center">
-      <div className="text-lg font-semibold text-neutral-900">{value}</div>
-      <div className="text-[11px] text-neutral-500">{label}</div>
+    <div className="rounded-xl border bg-white p-3 text-center dark:border-neutral-800 dark:bg-neutral-900">
+      <div className="text-lg font-semibold text-neutral-900 dark:text-neutral-100">
+        {value}
+      </div>
+      <div className="text-[11px] text-neutral-500 dark:text-neutral-400">
+        {label}
+      </div>
     </div>
   );
 }
@@ -67,13 +71,15 @@ export default function Home() {
       {/* Greeting + streak */}
       <div className="flex items-start justify-between">
         <div>
-          <div className="text-xs text-neutral-500">{dateLabel}</div>
-          <h1 className="text-xl font-semibold text-neutral-900">
+          <div className="text-xs text-neutral-500 dark:text-neutral-400">
+            {dateLabel}
+          </div>
+          <h1 className="text-xl font-semibold text-neutral-900 dark:text-neutral-100">
             {greeting()}
           </h1>
         </div>
         {streak > 0 && (
-          <span className="inline-flex items-center gap-1 rounded-full border bg-white px-3 py-1 text-sm">
+          <span className="inline-flex items-center gap-1 rounded-full border bg-white px-3 py-1 text-sm dark:border-neutral-800 dark:bg-neutral-900">
             <span aria-hidden>🔥</span>
             <span className="font-semibold">{streak}</span>
             <span className="sr-only">day streak</span>
@@ -82,16 +88,16 @@ export default function Home() {
       </div>
 
       {/* Today's plan */}
-      <div className="rounded-2xl border bg-white p-4">
-        <div className="text-[11px] uppercase tracking-wide text-neutral-500">
+      <div className="rounded-2xl border bg-white p-4 dark:border-neutral-800 dark:bg-neutral-900">
+        <div className="text-[11px] uppercase tracking-wide text-neutral-500 dark:text-neutral-400">
           Today
         </div>
         {todays.length ? (
           <>
-            <div className="mt-0.5 font-semibold text-neutral-900">
+            <div className="mt-0.5 font-semibold text-neutral-900 dark:text-neutral-100">
               {todays[0].name?.trim() || "Workout"}
             </div>
-            <div className="text-xs text-neutral-500">
+            <div className="text-xs text-neutral-500 dark:text-neutral-400">
               {todays[0].exercises?.length || 0} exercises ·{" "}
               {Math.round(workoutVolume(todays[0])).toLocaleString()} kg
             </div>
@@ -105,10 +111,10 @@ export default function Home() {
           </>
         ) : (
           <>
-            <div className="mt-0.5 font-semibold text-neutral-900">
+            <div className="mt-0.5 font-semibold text-neutral-900 dark:text-neutral-100">
               No workout logged yet
             </div>
-            <div className="text-xs text-neutral-500">
+            <div className="text-xs text-neutral-500 dark:text-neutral-400">
               Plan today&apos;s session to get started.
             </div>
             <button
@@ -133,8 +139,8 @@ export default function Home() {
       </div>
 
       {/* This week volume bars */}
-      <div className="rounded-2xl border bg-white p-4">
-        <div className="mb-3 text-[11px] uppercase tracking-wide text-neutral-500">
+      <div className="rounded-2xl border bg-white p-4 dark:border-neutral-800 dark:bg-neutral-900">
+        <div className="mb-3 text-[11px] uppercase tracking-wide text-neutral-500 dark:text-neutral-400">
           This week
         </div>
         <div className="flex h-24 items-stretch gap-2">
@@ -147,12 +153,14 @@ export default function Home() {
                 <div
                   className={[
                     "w-full rounded-md",
-                    i === todayIdx ? "bg-blue-600" : "bg-blue-200",
+                    i === todayIdx
+                      ? "bg-blue-600"
+                      : "bg-blue-200 dark:bg-blue-900",
                   ].join(" ")}
                   style={{ height: `${Math.max(4, (v / maxDay) * 100)}%` }}
                 />
               </div>
-              <span className="text-[10px] text-neutral-400">
+              <span className="text-[10px] text-neutral-400 dark:text-neutral-500">
                 {DAY_LABELS[i]}
               </span>
             </div>
@@ -163,7 +171,7 @@ export default function Home() {
       {/* Recent activity */}
       {recent.length > 0 && (
         <div className="space-y-2">
-          <div className="text-[11px] uppercase tracking-wide text-neutral-500">
+          <div className="text-[11px] uppercase tracking-wide text-neutral-500 dark:text-neutral-400">
             Recent
           </div>
           {recent.map((w) => (
@@ -171,15 +179,17 @@ export default function Home() {
               key={w.id}
               type="button"
               onClick={() => setTab("workouts")}
-              className="flex w-full items-center justify-between rounded-xl border bg-white p-3 text-left transition hover:bg-neutral-50"
+              className="flex w-full items-center justify-between rounded-xl border bg-white p-3 text-left transition hover:bg-neutral-50 dark:border-neutral-800 dark:bg-neutral-900 dark:hover:bg-neutral-800"
             >
               <div>
-                <div className="text-sm font-medium text-neutral-900">
+                <div className="text-sm font-medium text-neutral-900 dark:text-neutral-100">
                   {w.name?.trim() || "Workout"}
                 </div>
-                <div className="text-[11px] text-neutral-500">{w.date}</div>
+                <div className="text-[11px] text-neutral-500 dark:text-neutral-400">
+                  {w.date}
+                </div>
               </div>
-              <div className="text-xs text-neutral-500">
+              <div className="text-xs text-neutral-500 dark:text-neutral-400">
                 {w.exercises?.length || 0} ex ·{" "}
                 {Math.round(workoutVolume(w)).toLocaleString()} kg
               </div>

--- a/src/components/Home.test.jsx
+++ b/src/components/Home.test.jsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { AppProvider } from "../context/AppContext";
+import Home from "./Home";
+
+const renderHome = () =>
+  render(
+    <AppProvider>
+      <Home />
+    </AppProvider>,
+  );
+
+describe("Home", () => {
+  it("greets the user", () => {
+    renderHome();
+    expect(
+      screen.getByRole("heading", { name: /Good (morning|afternoon|evening)/ }),
+    ).toBeInTheDocument();
+  });
+
+  it("prompts to plan a workout when none is logged today", () => {
+    renderHome();
+    expect(
+      screen.getByRole("button", { name: /Plan a workout/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("hides the streak pill at a zero streak", () => {
+    renderHome();
+    expect(screen.queryByText(/day streak/i)).not.toBeInTheDocument();
+  });
+});

--- a/src/components/Home.test.jsx
+++ b/src/components/Home.test.jsx
@@ -18,10 +18,13 @@ describe("Home", () => {
     ).toBeInTheDocument();
   });
 
-  it("prompts to plan a workout when none is logged today", () => {
+  it("offers to start or plan a workout when none is logged today", () => {
     renderHome();
     expect(
-      screen.getByRole("button", { name: /Plan a workout/i }),
+      screen.getByRole("button", { name: /Start workout/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Plan ahead/i }),
     ).toBeInTheDocument();
   });
 

--- a/src/components/LiveSession.jsx
+++ b/src/components/LiveSession.jsx
@@ -13,7 +13,12 @@ import {
 import WeightRepInputs from "./WeightRepInputs";
 import AddExerciseInput from "./AddExerciseInput";
 
-const REST_DEFAULT = 90;
+// Rest-timer presets: [label, seconds].
+const REST_PRESETS = [
+  ["3 min", 180],
+  ["2 min", 120],
+  ["1.5 min", 90],
+];
 
 export default function LiveSession() {
   const {
@@ -284,13 +289,21 @@ export default function LiveSession() {
         <div className="mx-auto max-w-3xl space-y-3">
           {/* Rest timer (manual) */}
           {restLeft == null ? (
-            <button
-              type="button"
-              onClick={() => setRestLeft(REST_DEFAULT)}
-              className="flex w-full items-center justify-center gap-2 rounded-xl bg-neutral-100 py-2 text-sm font-medium text-neutral-700 transition hover:bg-neutral-200 dark:bg-neutral-800 dark:text-neutral-200 dark:hover:bg-neutral-700"
-            >
-              Start rest timer
-            </button>
+            <div className="flex items-center gap-2">
+              <span className="text-xs text-neutral-500 dark:text-neutral-400">
+                Rest
+              </span>
+              {REST_PRESETS.map(([label, secs]) => (
+                <button
+                  key={secs}
+                  type="button"
+                  onClick={() => setRestLeft(secs)}
+                  className="flex-1 rounded-xl bg-neutral-100 py-2 text-sm font-medium text-neutral-700 transition hover:bg-neutral-200 dark:bg-neutral-800 dark:text-neutral-200 dark:hover:bg-neutral-700"
+                >
+                  {label}
+                </button>
+              ))}
+            </div>
           ) : (
             <div className="flex items-center justify-between gap-2 rounded-xl bg-blue-50 px-3 py-2 dark:bg-neutral-800">
               <span className="text-sm font-medium text-blue-700 dark:text-blue-300">

--- a/src/components/LiveSession.jsx
+++ b/src/components/LiveSession.jsx
@@ -9,7 +9,10 @@ import {
   doneCount,
   totalSets,
   formatClock,
+  remapIndexAfterMove,
+  remapDoneAfterMove,
 } from "../lib/liveSession";
+import { moveItem } from "../lib/arrayUtils";
 import WeightRepInputs from "./WeightRepInputs";
 import AddExerciseInput from "./AddExerciseInput";
 
@@ -118,6 +121,19 @@ export default function LiveSession() {
   const toggleSetDone = (exIdx, setIdx) =>
     setSession((s) => ({ ...s, done: toggleDone(s.done, exIdx, setIdx) }));
 
+  // Reorder exercises mid-session (e.g. a machine is taken). The done-map and
+  // the on-screen pointer are remapped so completed sets stay with their
+  // exercise.
+  const moveExercise = (from, to) => {
+    if (to < 0 || to >= exs.length) return;
+    patchWorkout((w) => ({ ...w, exercises: moveItem(w.exercises, from, to) }));
+    setSession((s) => ({
+      ...s,
+      done: remapDoneAfterMove(s.done, from, to),
+      currentIdx: remapIndexAfterMove(s.currentIdx || 0, from, to),
+    }));
+  };
+
   const goTo = (idx) => setSession((s) => ({ ...s, currentIdx: idx }));
   const setName = (name) => patchWorkout((w) => ({ ...w, name }));
 
@@ -191,8 +207,32 @@ export default function LiveSession() {
               <div className="mb-1 text-[11px] uppercase tracking-wide text-neutral-500 dark:text-neutral-400">
                 Exercise {currentIdx + 1} of {exs.length}
               </div>
-              <div className="mb-3 text-lg font-semibold text-neutral-900 dark:text-neutral-100">
-                {current.exerciseName}
+              <div className="mb-3 flex items-center justify-between gap-2">
+                <div className="text-lg font-semibold text-neutral-900 dark:text-neutral-100">
+                  {current.exerciseName}
+                </div>
+                {exs.length > 1 && (
+                  <div className="flex shrink-0 items-center gap-1">
+                    <button
+                      type="button"
+                      onClick={() => moveExercise(currentIdx, currentIdx - 1)}
+                      disabled={currentIdx === 0}
+                      aria-label="Move exercise earlier"
+                      className="flex h-8 w-8 items-center justify-center rounded-lg border text-neutral-600 transition hover:bg-neutral-50 disabled:opacity-30 dark:border-neutral-700 dark:text-neutral-300 dark:hover:bg-neutral-800"
+                    >
+                      ↑
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => moveExercise(currentIdx, currentIdx + 1)}
+                      disabled={currentIdx === exs.length - 1}
+                      aria-label="Move exercise later"
+                      className="flex h-8 w-8 items-center justify-center rounded-lg border text-neutral-600 transition hover:bg-neutral-50 disabled:opacity-30 dark:border-neutral-700 dark:text-neutral-300 dark:hover:bg-neutral-800"
+                    >
+                      ↓
+                    </button>
+                  </div>
+                )}
               </div>
 
               {/* Column headers */}

--- a/src/components/LiveSession.jsx
+++ b/src/components/LiveSession.jsx
@@ -1,0 +1,350 @@
+import React, { useEffect, useState } from "react";
+import { useApp } from "../context/AppContext";
+import { toDisplayWeight, fromDisplayWeight } from "../lib/units";
+import { createExerciseEntry } from "../lib/exerciseUtils";
+import { MAX_SETS } from "../lib/constants";
+import {
+  isSetDone,
+  toggleDone,
+  doneCount,
+  totalSets,
+  formatClock,
+} from "../lib/liveSession";
+import WeightRepInputs from "./WeightRepInputs";
+import AddExerciseInput from "./AddExerciseInput";
+
+const REST_DEFAULT = 90;
+
+export default function LiveSession() {
+  const {
+    session,
+    setSession,
+    workouts,
+    setWorkouts,
+    exercises,
+    setExercises,
+    unit,
+    endSession,
+  } = useApp();
+
+  const workout = workouts.find((w) => w.id === session?.workoutId) || null;
+
+  // Tick the elapsed clock once a second.
+  const [nowTs, setNowTs] = useState(() => Date.now());
+  useEffect(() => {
+    const id = setInterval(() => setNowTs(Date.now()), 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  // Manual rest timer: null when idle, else seconds remaining. The countdown
+  // ticks inside the timeout callback and clears itself at zero, so the effect
+  // body never sets state synchronously.
+  const [restLeft, setRestLeft] = useState(null);
+  useEffect(() => {
+    if (restLeft == null || restLeft <= 0) return undefined;
+    const id = setTimeout(
+      () => setRestLeft((s) => (s != null && s <= 1 ? null : s - 1)),
+      1000,
+    );
+    return () => clearTimeout(id);
+  }, [restLeft]);
+
+  // If the workout vanished (e.g. deleted elsewhere), close the session.
+  useEffect(() => {
+    if (session && !workout) endSession();
+  }, [session, workout, endSession]);
+  if (!workout) return null;
+
+  const exs = workout.exercises || [];
+  const currentIdx = Math.min(
+    session.currentIdx || 0,
+    Math.max(0, exs.length - 1),
+  );
+  const current = exs[currentIdx] || null;
+  const elapsed = Math.floor((nowTs - (session.startedAt || nowTs)) / 1000);
+
+  // --- mutations (write through to the persisted workout) ---
+  const patchWorkout = (updater) =>
+    setWorkouts((prev) =>
+      prev.map((w) => (w.id === workout.id ? updater(w) : w)),
+    );
+
+  const mapExercise = (exIdx, fn) =>
+    patchWorkout((w) => ({
+      ...w,
+      exercises: w.exercises.map((ex, i) => (i === exIdx ? fn(ex) : ex)),
+    }));
+
+  const updateSet = (exIdx, setIdx, patch) =>
+    mapExercise(exIdx, (ex) => ({
+      ...ex,
+      sets: ex.sets.map((s, j) => (j === setIdx ? { ...s, ...patch } : s)),
+    }));
+
+  const addSet = (exIdx) =>
+    mapExercise(exIdx, (ex) => {
+      if (ex.sets.length >= MAX_SETS) return ex;
+      const last = ex.sets.at(-1) || { weight: 0, reps: 0 };
+      return {
+        ...ex,
+        sets: [
+          ...ex.sets,
+          { set: ex.sets.length + 1, weight: last.weight, reps: last.reps },
+        ],
+      };
+    });
+
+  const removeSet = (exIdx, setIdx) =>
+    mapExercise(exIdx, (ex) => ({
+      ...ex,
+      sets: ex.sets
+        .filter((_, j) => j !== setIdx)
+        .map((s, k) => ({ ...s, set: k + 1 })),
+    }));
+
+  const addExercise = (name) => {
+    const entry = createExerciseEntry(name, exercises, setExercises);
+    if (!entry) return;
+    const newIdx = exs.length;
+    patchWorkout((w) => ({ ...w, exercises: [...w.exercises, entry] }));
+    setSession((s) => ({ ...s, currentIdx: newIdx }));
+  };
+
+  const toggleSetDone = (exIdx, setIdx) =>
+    setSession((s) => ({ ...s, done: toggleDone(s.done, exIdx, setIdx) }));
+
+  const goTo = (idx) => setSession((s) => ({ ...s, currentIdx: idx }));
+  const setName = (name) => patchWorkout((w) => ({ ...w, name }));
+
+  const finish = () => {
+    // Drop an abandoned empty workout so it doesn't litter history.
+    if (exs.length === 0) {
+      setWorkouts((prev) => prev.filter((w) => w.id !== workout.id));
+    }
+    endSession();
+  };
+
+  const completed = doneCount(session.done);
+  const total = totalSets(workout);
+
+  const surface =
+    "rounded-2xl border bg-white dark:border-neutral-800 dark:bg-neutral-900";
+
+  return (
+    <div className="fixed inset-0 z-50 flex flex-col bg-neutral-50 dark:bg-neutral-950">
+      {/* Top bar */}
+      <div className="border-b bg-white px-4 py-3 dark:border-neutral-800 dark:bg-neutral-900">
+        <div className="mx-auto flex max-w-3xl items-center justify-between gap-3">
+          <div className="min-w-0 flex-1">
+            <input
+              value={workout.name || ""}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Workout"
+              className="w-full bg-transparent text-base font-semibold text-neutral-900 placeholder:text-neutral-400 focus:outline-none dark:text-neutral-100"
+            />
+            <div className="text-xs text-neutral-500 dark:text-neutral-400">
+              {formatClock(elapsed)} elapsed · {completed}/{total} sets
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={finish}
+            className="rounded-xl border border-blue-200 px-3 py-2 text-sm font-medium text-blue-600 transition hover:bg-blue-50 dark:border-blue-900 dark:text-blue-400 dark:hover:bg-neutral-800"
+          >
+            Finish
+          </button>
+        </div>
+      </div>
+
+      {/* Scrollable body */}
+      <div className="flex-1 overflow-y-auto px-4 py-4">
+        <div className="mx-auto max-w-3xl space-y-4">
+          {/* Exercise nav chips */}
+          {exs.length > 0 && (
+            <div className="flex gap-2 overflow-x-auto pb-1">
+              {exs.map((ex, i) => (
+                <button
+                  key={i}
+                  type="button"
+                  onClick={() => goTo(i)}
+                  className={[
+                    "whitespace-nowrap rounded-full px-3 py-1 text-xs transition",
+                    i === currentIdx
+                      ? "bg-blue-600 text-white"
+                      : "border bg-white text-neutral-600 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-300",
+                  ].join(" ")}
+                >
+                  {i + 1}. {ex.exerciseName}
+                </button>
+              ))}
+            </div>
+          )}
+
+          {/* Current exercise */}
+          {current ? (
+            <div className={`${surface} p-4`}>
+              <div className="mb-1 text-[11px] uppercase tracking-wide text-neutral-500 dark:text-neutral-400">
+                Exercise {currentIdx + 1} of {exs.length}
+              </div>
+              <div className="mb-3 text-lg font-semibold text-neutral-900 dark:text-neutral-100">
+                {current.exerciseName}
+              </div>
+
+              {/* Column headers */}
+              <div className="mb-1 grid grid-cols-[28px,1fr,40px] items-center gap-2 px-1 text-[10px] uppercase text-neutral-400 dark:text-neutral-500">
+                <span>Set</span>
+                <span className="grid grid-cols-2 gap-3">
+                  <span className="text-center">{unit}</span>
+                  <span className="text-center">reps</span>
+                </span>
+                <span className="text-center">done</span>
+              </div>
+
+              {/* Set rows */}
+              <div className="space-y-2">
+                {current.sets.map((s, j) => {
+                  const done = isSetDone(session.done, currentIdx, j);
+                  return (
+                    <div
+                      key={j}
+                      className="grid grid-cols-[28px,1fr,40px] items-center gap-2"
+                    >
+                      <button
+                        type="button"
+                        onClick={() => removeSet(currentIdx, j)}
+                        aria-label={`Remove set ${j + 1}`}
+                        className="text-sm text-neutral-500 hover:text-red-600 dark:text-neutral-400"
+                        title="Remove set"
+                      >
+                        {j + 1}
+                      </button>
+                      <WeightRepInputs
+                        weight={toDisplayWeight(s.weight, unit)}
+                        reps={s.reps}
+                        onWeightChange={(v) =>
+                          updateSet(currentIdx, j, {
+                            weight: fromDisplayWeight(v, unit),
+                          })
+                        }
+                        onRepsChange={(v) =>
+                          updateSet(currentIdx, j, { reps: v })
+                        }
+                      />
+                      <button
+                        type="button"
+                        onClick={() => toggleSetDone(currentIdx, j)}
+                        aria-label={`Mark set ${j + 1} done`}
+                        aria-pressed={done}
+                        className={[
+                          "mx-auto flex h-8 w-8 items-center justify-center rounded-full border text-sm transition",
+                          done
+                            ? "border-green-600 bg-green-600 text-white"
+                            : "border-neutral-300 text-neutral-400 hover:border-green-600 dark:border-neutral-600 dark:text-neutral-500",
+                        ].join(" ")}
+                      >
+                        ✓
+                      </button>
+                    </div>
+                  );
+                })}
+              </div>
+
+              <button
+                type="button"
+                onClick={() => addSet(currentIdx)}
+                disabled={current.sets.length >= MAX_SETS}
+                className="mt-3 flex w-full items-center justify-center gap-1 rounded-xl border border-dashed border-neutral-300 py-2 text-sm text-blue-600 transition hover:bg-neutral-50 disabled:opacity-40 dark:border-neutral-700 dark:text-blue-400 dark:hover:bg-neutral-800"
+              >
+                + Add set
+              </button>
+            </div>
+          ) : (
+            <div className={`${surface} p-4 text-center`}>
+              <div className="mb-1 font-semibold text-neutral-900 dark:text-neutral-100">
+                No exercises yet
+              </div>
+              <div className="text-sm text-neutral-500 dark:text-neutral-400">
+                Add your first exercise to start logging.
+              </div>
+            </div>
+          )}
+
+          {/* Add exercise */}
+          <div className={`${surface} p-4`}>
+            <div className="mb-2 text-[11px] uppercase tracking-wide text-neutral-500 dark:text-neutral-400">
+              Add exercise
+            </div>
+            <AddExerciseInput allExercises={exercises} onAdd={addExercise} />
+          </div>
+        </div>
+      </div>
+
+      {/* Bottom bar: rest timer + prev/next */}
+      <div className="border-t bg-white px-4 py-3 dark:border-neutral-800 dark:bg-neutral-900">
+        <div className="mx-auto max-w-3xl space-y-3">
+          {/* Rest timer (manual) */}
+          {restLeft == null ? (
+            <button
+              type="button"
+              onClick={() => setRestLeft(REST_DEFAULT)}
+              className="flex w-full items-center justify-center gap-2 rounded-xl bg-neutral-100 py-2 text-sm font-medium text-neutral-700 transition hover:bg-neutral-200 dark:bg-neutral-800 dark:text-neutral-200 dark:hover:bg-neutral-700"
+            >
+              Start rest timer
+            </button>
+          ) : (
+            <div className="flex items-center justify-between gap-2 rounded-xl bg-blue-50 px-3 py-2 dark:bg-neutral-800">
+              <span className="text-sm font-medium text-blue-700 dark:text-blue-300">
+                Rest · {formatClock(restLeft)}
+              </span>
+              <span className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={() => setRestLeft((s) => Math.max(0, s - 15))}
+                  className="rounded-lg px-2 py-1 text-xs text-blue-700 hover:bg-blue-100 dark:text-blue-300 dark:hover:bg-neutral-700"
+                >
+                  −15s
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setRestLeft((s) => s + 15)}
+                  className="rounded-lg px-2 py-1 text-xs text-blue-700 hover:bg-blue-100 dark:text-blue-300 dark:hover:bg-neutral-700"
+                >
+                  +15s
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setRestLeft(null)}
+                  className="rounded-lg px-2 py-1 text-xs font-medium text-blue-700 hover:bg-blue-100 dark:text-blue-300 dark:hover:bg-neutral-700"
+                >
+                  Skip
+                </button>
+              </span>
+            </div>
+          )}
+
+          {/* Prev / Next */}
+          {exs.length > 1 && (
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={() => goTo(Math.max(0, currentIdx - 1))}
+                disabled={currentIdx === 0}
+                className="flex-1 rounded-xl border py-2 text-sm transition hover:bg-neutral-50 disabled:opacity-40 dark:border-neutral-700 dark:text-neutral-200 dark:hover:bg-neutral-800"
+              >
+                ← Prev
+              </button>
+              <button
+                type="button"
+                onClick={() => goTo(Math.min(exs.length - 1, currentIdx + 1))}
+                disabled={currentIdx >= exs.length - 1}
+                className="flex-1 rounded-xl bg-blue-600 py-2 text-sm font-medium text-white transition hover:bg-blue-700 disabled:opacity-40"
+              >
+                Next →
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/LiveSession.jsx
+++ b/src/components/LiveSession.jsx
@@ -14,6 +14,8 @@ import { moveItem } from "../lib/arrayUtils";
 import WeightRepInputs from "./WeightRepInputs";
 import AddExerciseInput from "./AddExerciseInput";
 import RpeFeedback from "./RpeFeedback";
+import { Trash2 } from "./ui/Icons";
+import { useConfirm } from "./ConfirmDialog";
 
 // Rest-timer presets: [label, seconds].
 const REST_PRESETS = [
@@ -60,6 +62,9 @@ export default function LiveSession() {
   // mouse alike (HTML5 drag-and-drop doesn't fire on touch).
   const [dragIdx, setDragIdx] = useState(null);
   const suppressClickRef = useRef(false);
+  // Inline "replace exercise" picker for the current exercise.
+  const [swapping, setSwapping] = useState(false);
+  const confirm = useConfirm();
 
   // If the workout vanished (e.g. deleted elsewhere), close the session.
   useEffect(() => {
@@ -116,17 +121,49 @@ export default function LiveSession() {
         .map((s, k) => ({ ...s, set: k + 1 })),
     }));
 
-  const addExercise = (name) => {
+  // Build a fresh entry for `name`: prefilled weight from its own history, but
+  // reps cleared so it reads as "to do".
+  const freshEntry = (name) => {
     const entry = createExerciseEntry(name, exercises, setExercises);
-    if (!entry) return;
-    // Keep the prefilled weight but clear reps so the set reads as "to do".
-    const fresh = {
-      ...entry,
-      sets: entry.sets.map((s) => ({ ...s, reps: 0 })),
-    };
+    if (!entry) return null;
+    return { ...entry, sets: entry.sets.map((s) => ({ ...s, reps: 0 })) };
+  };
+
+  const addExercise = (name) => {
+    const fresh = freshEntry(name);
+    if (!fresh) return;
     const newIdx = exs.length;
     patchWorkout((w) => ({ ...w, exercises: [...w.exercises, fresh] }));
     setSession((s) => ({ ...s, currentIdx: newIdx }));
+  };
+
+  // Swap the current exercise for another in place (machine taken, etc.).
+  const replaceExercise = (exIdx, name) => {
+    const fresh = freshEntry(name);
+    if (!fresh) return;
+    mapExercise(exIdx, () => fresh);
+    setSwapping(false);
+  };
+
+  // Drop an exercise from the session (confirmed — it discards its logged sets).
+  const removeExercise = (exIdx) => {
+    confirm({
+      title: "Remove this exercise?",
+      message: "It will be taken out of this workout, along with its sets.",
+      confirmText: "Remove",
+      tone: "destructive",
+    }).then((ok) => {
+      if (!ok) return;
+      patchWorkout((w) => ({
+        ...w,
+        exercises: w.exercises.filter((_, i) => i !== exIdx),
+      }));
+      const newLen = exs.length - 1;
+      setSession((s) => ({
+        ...s,
+        currentIdx: Math.max(0, Math.min(s.currentIdx || 0, newLen - 1)),
+      }));
+    });
   };
 
   // Reorder exercises mid-session (e.g. a machine is taken). Completion lives on
@@ -175,7 +212,10 @@ export default function LiveSession() {
     window.addEventListener("pointerup", onUp);
   };
 
-  const goTo = (idx) => setSession((s) => ({ ...s, currentIdx: idx }));
+  const goTo = (idx) => {
+    setSwapping(false);
+    setSession((s) => ({ ...s, currentIdx: idx }));
+  };
   const setName = (name) => patchWorkout((w) => ({ ...w, name }));
 
   const finish = () => {
@@ -259,32 +299,67 @@ export default function LiveSession() {
                 Exercise {currentIdx + 1} of {exs.length}
               </div>
               <div className="mb-3 flex items-center justify-between gap-2">
-                <div className="text-lg font-semibold text-neutral-900 dark:text-neutral-100">
+                <div className="min-w-0 flex-1 truncate text-lg font-semibold text-neutral-900 dark:text-neutral-100">
                   {current.exerciseName}
                 </div>
-                {exs.length > 1 && (
-                  <div className="flex shrink-0 items-center gap-1">
-                    <button
-                      type="button"
-                      onClick={() => moveExercise(currentIdx, currentIdx - 1)}
-                      disabled={currentIdx === 0}
-                      aria-label="Move exercise earlier"
-                      className="flex h-8 w-8 items-center justify-center rounded-lg border text-neutral-600 transition hover:bg-neutral-50 disabled:opacity-30 dark:border-neutral-700 dark:text-neutral-300 dark:hover:bg-neutral-800"
-                    >
-                      ↑
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => moveExercise(currentIdx, currentIdx + 1)}
-                      disabled={currentIdx === exs.length - 1}
-                      aria-label="Move exercise later"
-                      className="flex h-8 w-8 items-center justify-center rounded-lg border text-neutral-600 transition hover:bg-neutral-50 disabled:opacity-30 dark:border-neutral-700 dark:text-neutral-300 dark:hover:bg-neutral-800"
-                    >
-                      ↓
-                    </button>
-                  </div>
-                )}
+                <div className="flex shrink-0 items-center gap-1">
+                  {exs.length > 1 && (
+                    <>
+                      <button
+                        type="button"
+                        onClick={() => moveExercise(currentIdx, currentIdx - 1)}
+                        disabled={currentIdx === 0}
+                        aria-label="Move exercise earlier"
+                        className="flex h-8 w-8 items-center justify-center rounded-lg border text-neutral-600 transition hover:bg-neutral-50 disabled:opacity-30 dark:border-neutral-700 dark:text-neutral-300 dark:hover:bg-neutral-800"
+                      >
+                        ↑
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => moveExercise(currentIdx, currentIdx + 1)}
+                        disabled={currentIdx === exs.length - 1}
+                        aria-label="Move exercise later"
+                        className="flex h-8 w-8 items-center justify-center rounded-lg border text-neutral-600 transition hover:bg-neutral-50 disabled:opacity-30 dark:border-neutral-700 dark:text-neutral-300 dark:hover:bg-neutral-800"
+                      >
+                        ↓
+                      </button>
+                    </>
+                  )}
+                  <button
+                    type="button"
+                    onClick={() => setSwapping((v) => !v)}
+                    aria-label="Replace exercise"
+                    aria-pressed={swapping}
+                    className={[
+                      "flex h-8 w-8 items-center justify-center rounded-lg border text-neutral-600 transition hover:bg-neutral-50 dark:border-neutral-700 dark:text-neutral-300 dark:hover:bg-neutral-800",
+                      swapping ? "bg-neutral-100 dark:bg-neutral-800" : "",
+                    ].join(" ")}
+                  >
+                    ⇄
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => removeExercise(currentIdx)}
+                    aria-label="Remove exercise"
+                    className="flex h-8 w-8 items-center justify-center rounded-lg border text-red-600 transition hover:bg-red-50 dark:border-neutral-700 dark:hover:bg-neutral-800"
+                  >
+                    <Trash2 />
+                  </button>
+                </div>
               </div>
+
+              {/* Inline replace picker */}
+              {swapping && (
+                <div className="mb-3 rounded-xl border border-dashed border-neutral-300 p-3 dark:border-neutral-700">
+                  <div className="mb-2 text-[11px] uppercase tracking-wide text-neutral-500 dark:text-neutral-400">
+                    Replace with
+                  </div>
+                  <AddExerciseInput
+                    allExercises={exercises}
+                    onAdd={(name) => replaceExercise(currentIdx, name)}
+                  />
+                </div>
+              )}
 
               {/* Column headers */}
               <div className="mb-1 grid grid-cols-[28px,1fr,28px] items-center gap-2 px-1 text-[10px] uppercase text-neutral-400 dark:text-neutral-500">

--- a/src/components/LiveSession.jsx
+++ b/src/components/LiveSession.jsx
@@ -1,20 +1,19 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { useApp } from "../context/AppContext";
 import { toDisplayWeight, fromDisplayWeight } from "../lib/units";
 import { createExerciseEntry } from "../lib/exerciseUtils";
 import { MAX_SETS } from "../lib/constants";
 import {
-  isSetDone,
-  toggleDone,
-  doneCount,
+  isLogged,
+  completedSets,
   totalSets,
   formatClock,
   remapIndexAfterMove,
-  remapDoneAfterMove,
 } from "../lib/liveSession";
 import { moveItem } from "../lib/arrayUtils";
 import WeightRepInputs from "./WeightRepInputs";
 import AddExerciseInput from "./AddExerciseInput";
+import RpeFeedback from "./RpeFeedback";
 
 // Rest-timer presets: [label, seconds].
 const REST_PRESETS = [
@@ -57,6 +56,11 @@ export default function LiveSession() {
     return () => clearTimeout(id);
   }, [restLeft]);
 
+  // Drag-to-reorder the exercise chips. Pointer-based so it works on touch and
+  // mouse alike (HTML5 drag-and-drop doesn't fire on touch).
+  const [dragIdx, setDragIdx] = useState(null);
+  const suppressClickRef = useRef(false);
+
   // If the workout vanished (e.g. deleted elsewhere), close the session.
   useEffect(() => {
     if (session && !workout) endSession();
@@ -89,15 +93,17 @@ export default function LiveSession() {
       sets: ex.sets.map((s, j) => (j === setIdx ? { ...s, ...patch } : s)),
     }));
 
+  // A new set carries the previous set's weight as a convenience, but starts
+  // with no reps — entering reps is what marks it logged.
   const addSet = (exIdx) =>
     mapExercise(exIdx, (ex) => {
       if (ex.sets.length >= MAX_SETS) return ex;
-      const last = ex.sets.at(-1) || { weight: 0, reps: 0 };
+      const last = ex.sets.at(-1) || { weight: 0 };
       return {
         ...ex,
         sets: [
           ...ex.sets,
-          { set: ex.sets.length + 1, weight: last.weight, reps: last.reps },
+          { set: ex.sets.length + 1, weight: last.weight, reps: 0 },
         ],
       };
     });
@@ -113,25 +119,60 @@ export default function LiveSession() {
   const addExercise = (name) => {
     const entry = createExerciseEntry(name, exercises, setExercises);
     if (!entry) return;
+    // Keep the prefilled weight but clear reps so the set reads as "to do".
+    const fresh = {
+      ...entry,
+      sets: entry.sets.map((s) => ({ ...s, reps: 0 })),
+    };
     const newIdx = exs.length;
-    patchWorkout((w) => ({ ...w, exercises: [...w.exercises, entry] }));
+    patchWorkout((w) => ({ ...w, exercises: [...w.exercises, fresh] }));
     setSession((s) => ({ ...s, currentIdx: newIdx }));
   };
 
-  const toggleSetDone = (exIdx, setIdx) =>
-    setSession((s) => ({ ...s, done: toggleDone(s.done, exIdx, setIdx) }));
-
-  // Reorder exercises mid-session (e.g. a machine is taken). The done-map and
-  // the on-screen pointer are remapped so completed sets stay with their
-  // exercise.
+  // Reorder exercises mid-session (e.g. a machine is taken). Completion lives on
+  // each set's reps, so it moves with the exercise automatically; only the
+  // on-screen pointer needs remapping to stay on the same exercise.
   const moveExercise = (from, to) => {
     if (to < 0 || to >= exs.length) return;
     patchWorkout((w) => ({ ...w, exercises: moveItem(w.exercises, from, to) }));
     setSession((s) => ({
       ...s,
-      done: remapDoneAfterMove(s.done, from, to),
       currentIdx: remapIndexAfterMove(s.currentIdx || 0, from, to),
     }));
+  };
+
+  // Begin a chip drag. Window listeners live only for the duration of the drag
+  // and close over the current `moveExercise`, reordering live as the pointer
+  // passes over other chips.
+  const startChipDrag = (e, fromIdx) => {
+    const start = { x: e.clientX, y: e.clientY };
+    let idx = fromIdx;
+    let active = false;
+    const onMove = (ev) => {
+      if (!active) {
+        if (Math.hypot(ev.clientX - start.x, ev.clientY - start.y) < 6) return;
+        active = true;
+        setDragIdx(idx);
+      }
+      const chip = document
+        .elementFromPoint(ev.clientX, ev.clientY)
+        ?.closest("[data-chip-idx]");
+      if (!chip) return;
+      const over = Number(chip.getAttribute("data-chip-idx"));
+      if (Number.isInteger(over) && over !== idx) {
+        moveExercise(idx, over);
+        idx = over;
+        setDragIdx(over);
+      }
+    };
+    const onUp = () => {
+      if (active) suppressClickRef.current = true; // swallow the trailing click
+      setDragIdx(null);
+      window.removeEventListener("pointermove", onMove);
+      window.removeEventListener("pointerup", onUp);
+    };
+    window.addEventListener("pointermove", onMove);
+    window.addEventListener("pointerup", onUp);
   };
 
   const goTo = (idx) => setSession((s) => ({ ...s, currentIdx: idx }));
@@ -145,7 +186,7 @@ export default function LiveSession() {
     endSession();
   };
 
-  const completed = doneCount(session.done);
+  const completed = completedSets(workout);
   const total = totalSets(workout);
 
   const surface =
@@ -180,16 +221,26 @@ export default function LiveSession() {
       {/* Scrollable body */}
       <div className="flex-1 overflow-y-auto px-4 py-4">
         <div className="mx-auto max-w-3xl space-y-4">
-          {/* Exercise nav chips */}
+          {/* Exercise nav chips — tap to jump, drag to reorder */}
           {exs.length > 0 && (
             <div className="flex gap-2 overflow-x-auto pb-1">
               {exs.map((ex, i) => (
                 <button
                   key={i}
                   type="button"
-                  onClick={() => goTo(i)}
+                  data-chip-idx={i}
+                  style={{ touchAction: "none" }}
+                  onPointerDown={(e) => startChipDrag(e, i)}
+                  onClick={() => {
+                    if (suppressClickRef.current) {
+                      suppressClickRef.current = false;
+                      return;
+                    }
+                    goTo(i);
+                  }}
                   className={[
-                    "whitespace-nowrap rounded-full px-3 py-1 text-xs transition",
+                    "cursor-grab select-none whitespace-nowrap rounded-full px-3 py-1 text-xs transition active:cursor-grabbing",
+                    dragIdx === i ? "opacity-60 " : "",
                     i === currentIdx
                       ? "bg-blue-600 text-white"
                       : "border bg-white text-neutral-600 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-300",
@@ -236,62 +287,56 @@ export default function LiveSession() {
               </div>
 
               {/* Column headers */}
-              <div className="mb-1 grid grid-cols-[28px,1fr,40px] items-center gap-2 px-1 text-[10px] uppercase text-neutral-400 dark:text-neutral-500">
+              <div className="mb-1 grid grid-cols-[28px,1fr,28px] items-center gap-2 px-1 text-[10px] uppercase text-neutral-400 dark:text-neutral-500">
                 <span>Set</span>
                 <span className="grid grid-cols-2 gap-3">
                   <span className="text-center">{unit}</span>
                   <span className="text-center">reps</span>
                 </span>
-                <span className="text-center">done</span>
+                <span className="text-center">✓</span>
               </div>
 
-              {/* Set rows */}
+              {/* Set rows — a set reads as logged once it has reps */}
               <div className="space-y-2">
-                {current.sets.map((s, j) => {
-                  const done = isSetDone(session.done, currentIdx, j);
-                  return (
-                    <div
-                      key={j}
-                      className="grid grid-cols-[28px,1fr,40px] items-center gap-2"
+                {current.sets.map((s, j) => (
+                  <div
+                    key={j}
+                    className="grid grid-cols-[28px,1fr,28px] items-center gap-2"
+                  >
+                    <button
+                      type="button"
+                      onClick={() => removeSet(currentIdx, j)}
+                      aria-label={`Remove set ${j + 1}`}
+                      className="text-sm text-neutral-500 hover:text-red-600 dark:text-neutral-400"
+                      title="Remove set"
                     >
-                      <button
-                        type="button"
-                        onClick={() => removeSet(currentIdx, j)}
-                        aria-label={`Remove set ${j + 1}`}
-                        className="text-sm text-neutral-500 hover:text-red-600 dark:text-neutral-400"
-                        title="Remove set"
-                      >
-                        {j + 1}
-                      </button>
-                      <WeightRepInputs
-                        weight={toDisplayWeight(s.weight, unit)}
-                        reps={s.reps}
-                        onWeightChange={(v) =>
-                          updateSet(currentIdx, j, {
-                            weight: fromDisplayWeight(v, unit),
-                          })
-                        }
-                        onRepsChange={(v) =>
-                          updateSet(currentIdx, j, { reps: v })
-                        }
-                      />
-                      <button
-                        type="button"
-                        onClick={() => toggleSetDone(currentIdx, j)}
-                        aria-label={`Mark set ${j + 1} done`}
-                        aria-pressed={done}
-                        className={[
-                          "mx-auto flex h-8 w-8 items-center justify-center rounded-full border text-sm transition",
-                          done
-                            ? "border-green-600 bg-green-600 text-white"
-                            : "border-neutral-300 text-neutral-400 hover:border-green-600 dark:border-neutral-600 dark:text-neutral-500",
-                        ].join(" ")}
-                      >
-                        ✓
-                      </button>
-                    </div>
-                  );
-                })}
+                      {j + 1}
+                    </button>
+                    <WeightRepInputs
+                      weight={toDisplayWeight(s.weight, unit)}
+                      reps={s.reps}
+                      onWeightChange={(v) =>
+                        updateSet(currentIdx, j, {
+                          weight: fromDisplayWeight(v, unit),
+                        })
+                      }
+                      onRepsChange={(v) =>
+                        updateSet(currentIdx, j, { reps: v })
+                      }
+                    />
+                    <span
+                      aria-hidden="true"
+                      className={[
+                        "mx-auto text-base",
+                        isLogged(s)
+                          ? "text-green-600 dark:text-green-500"
+                          : "text-transparent",
+                      ].join(" ")}
+                    >
+                      ✓
+                    </span>
+                  </div>
+                ))}
               </div>
 
               <button
@@ -302,6 +347,17 @@ export default function LiveSession() {
               >
                 + Add set
               </button>
+
+              {/* RPE + feedback for this exercise */}
+              <div className="mt-3 border-t pt-3 dark:border-neutral-800">
+                <RpeFeedback
+                  rpe={current.rpe ?? null}
+                  feedback={current.feedback ?? ""}
+                  onChange={(patch) =>
+                    mapExercise(currentIdx, (ex) => ({ ...ex, ...patch }))
+                  }
+                />
+              </div>
             </div>
           ) : (
             <div className={`${surface} p-4 text-center`}>

--- a/src/components/LiveSession.test.jsx
+++ b/src/components/LiveSession.test.jsx
@@ -56,11 +56,11 @@ describe("LiveSession", () => {
     expect(screen.getAllByRole("spinbutton")).toHaveLength(4);
   });
 
-  it("starts and skips the manual rest timer", async () => {
+  it("starts a rest timer from a preset and skips it", async () => {
     const user = userEvent.setup();
     seedAndRender();
-    await user.click(screen.getByRole("button", { name: /Start rest timer/i }));
-    expect(screen.getByText(/Rest ·/)).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "2 min" }));
+    expect(screen.getByText("Rest · 2:00")).toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: "Skip" }));
     expect(screen.queryByText(/Rest ·/)).not.toBeInTheDocument();
   });

--- a/src/components/LiveSession.test.jsx
+++ b/src/components/LiveSession.test.jsx
@@ -2,8 +2,19 @@ import React from "react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { AppProvider } from "../context/AppContext";
+import { ConfirmProvider } from "./ConfirmDialog";
 import { saveLS, K_WO, K_SESSION } from "../lib/storage";
 import LiveSession from "./LiveSession";
+
+function renderLive() {
+  return render(
+    <ConfirmProvider>
+      <AppProvider>
+        <LiveSession />
+      </AppProvider>
+    </ConfirmProvider>,
+  );
+}
 
 function seedAndRender() {
   saveLS(K_WO, [
@@ -17,11 +28,23 @@ function seedAndRender() {
     },
   ]);
   saveLS(K_SESSION, { workoutId: "w1", startedAt: Date.now(), currentIdx: 0 });
-  return render(
-    <AppProvider>
-      <LiveSession />
-    </AppProvider>,
-  );
+  return renderLive();
+}
+
+function seedTwo() {
+  saveLS(K_WO, [
+    {
+      id: "w2",
+      date: "2026-06-13",
+      name: "Push Day",
+      exercises: [
+        { exerciseName: "Bench", sets: [{ set: 1, weight: 80, reps: 8 }] },
+        { exerciseName: "Squat", sets: [{ set: 1, weight: 100, reps: 5 }] },
+      ],
+    },
+  ]);
+  saveLS(K_SESSION, { workoutId: "w2", startedAt: Date.now(), currentIdx: 0 });
+  return renderLive();
 }
 
 describe("LiveSession", () => {
@@ -68,27 +91,7 @@ describe("LiveSession", () => {
 
   it("reorders exercises and keeps the pointer on the moved one", async () => {
     const user = userEvent.setup();
-    saveLS(K_WO, [
-      {
-        id: "w2",
-        date: "2026-06-13",
-        name: "Push Day",
-        exercises: [
-          { exerciseName: "Bench", sets: [{ set: 1, weight: 80, reps: 8 }] },
-          { exerciseName: "Squat", sets: [{ set: 1, weight: 100, reps: 5 }] },
-        ],
-      },
-    ]);
-    saveLS(K_SESSION, {
-      workoutId: "w2",
-      startedAt: Date.now(),
-      currentIdx: 0,
-    });
-    render(
-      <AppProvider>
-        <LiveSession />
-      </AppProvider>,
-    );
+    seedTwo();
 
     expect(screen.getByText("Exercise 1 of 2")).toBeInTheDocument();
     await user.click(
@@ -101,6 +104,40 @@ describe("LiveSession", () => {
     expect(
       screen.getByRole("button", { name: /1\. Squat/ }),
     ).toBeInTheDocument();
+  });
+
+  it("replaces the current exercise in place", async () => {
+    const user = userEvent.setup();
+    seedTwo();
+    await user.click(screen.getByRole("button", { name: "Replace exercise" }));
+    // The swap picker is the first exercise search box on screen.
+    const search = screen.getAllByPlaceholderText(/Search by name/i)[0];
+    await user.type(search, "Dips");
+    await user.click(screen.getAllByRole("button", { name: /^Add$/ })[0]);
+
+    // Bench (exercise 1) becomes Dips; Squat is untouched at position 2.
+    expect(
+      screen.getByRole("button", { name: /1\. Dips/ }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /1\. Bench/ }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /2\. Squat/ }),
+    ).toBeInTheDocument();
+  });
+
+  it("removes the current exercise after confirming", async () => {
+    const user = userEvent.setup();
+    seedTwo();
+    expect(screen.getByText("Exercise 1 of 2")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Remove exercise" }));
+    // Confirm in the dialog.
+    await user.click(screen.getByRole("button", { name: "Remove" }));
+
+    expect(screen.getByText("Exercise 1 of 1")).toBeInTheDocument();
+    expect(screen.queryByText(/Bench/)).not.toBeInTheDocument();
+    expect(screen.getByText("Squat")).toBeInTheDocument();
   });
 
   it("closes the session when finished", async () => {

--- a/src/components/LiveSession.test.jsx
+++ b/src/components/LiveSession.test.jsx
@@ -16,12 +16,7 @@ function seedAndRender() {
       ],
     },
   ]);
-  saveLS(K_SESSION, {
-    workoutId: "w1",
-    startedAt: Date.now(),
-    currentIdx: 0,
-    done: {},
-  });
+  saveLS(K_SESSION, { workoutId: "w1", startedAt: Date.now(), currentIdx: 0 });
   return render(
     <AppProvider>
       <LiveSession />
@@ -34,17 +29,16 @@ describe("LiveSession", () => {
     seedAndRender();
     expect(screen.getByText("Bench")).toBeInTheDocument();
     expect(screen.getByText(/Exercise 1 of 1/)).toBeInTheDocument();
-    expect(screen.getByText(/0\/1 sets/)).toBeInTheDocument();
+    // The seeded set has reps, so it already counts as logged.
+    expect(screen.getByText(/1\/1 sets/)).toBeInTheDocument();
   });
 
-  it("marks a set done and updates the counter", async () => {
+  it("an added set starts unlogged until reps are entered", async () => {
     const user = userEvent.setup();
     seedAndRender();
-    const doneBtn = screen.getByRole("button", { name: /Mark set 1 done/i });
-    expect(doneBtn).toHaveAttribute("aria-pressed", "false");
-    await user.click(doneBtn);
-    expect(doneBtn).toHaveAttribute("aria-pressed", "true");
-    expect(screen.getByText(/1\/1 sets/)).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /Add set/i }));
+    // Two sets now, but the new one has no reps yet → still 1 logged of 2.
+    expect(screen.getByText(/1\/2 sets/)).toBeInTheDocument();
   });
 
   it("adds a set", async () => {
@@ -56,6 +50,13 @@ describe("LiveSession", () => {
     expect(screen.getAllByRole("spinbutton")).toHaveLength(4);
   });
 
+  it("offers an RPE / feedback control for the exercise", () => {
+    seedAndRender();
+    expect(
+      screen.getByRole("button", { name: /RPE \/ note/i }),
+    ).toBeInTheDocument();
+  });
+
   it("starts a rest timer from a preset and skips it", async () => {
     const user = userEvent.setup();
     seedAndRender();
@@ -65,7 +66,7 @@ describe("LiveSession", () => {
     expect(screen.queryByText(/Rest ·/)).not.toBeInTheDocument();
   });
 
-  it("reorders exercises, keeping the done flag and pointer on the moved one", async () => {
+  it("reorders exercises and keeps the pointer on the moved one", async () => {
     const user = userEvent.setup();
     saveLS(K_WO, [
       {
@@ -82,7 +83,6 @@ describe("LiveSession", () => {
       workoutId: "w2",
       startedAt: Date.now(),
       currentIdx: 0,
-      done: {},
     });
     render(
       <AppProvider>
@@ -91,18 +91,16 @@ describe("LiveSession", () => {
     );
 
     expect(screen.getByText("Exercise 1 of 2")).toBeInTheDocument();
-    // Complete Bench's set, then move Bench later.
-    await user.click(screen.getByRole("button", { name: /Mark set 1 done/i }));
     await user.click(
       screen.getByRole("button", { name: /Move exercise later/i }),
     );
 
-    // The view follows Bench to position 2, and its done flag came along.
+    // The view follows Bench to position 2; the first chip is now Squat.
     expect(screen.getByText("Exercise 2 of 2")).toBeInTheDocument();
     expect(screen.getByText("Bench")).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: /Mark set 1 done/i }),
-    ).toHaveAttribute("aria-pressed", "true");
+      screen.getByRole("button", { name: /1\. Squat/ }),
+    ).toBeInTheDocument();
   });
 
   it("closes the session when finished", async () => {

--- a/src/components/LiveSession.test.jsx
+++ b/src/components/LiveSession.test.jsx
@@ -65,6 +65,46 @@ describe("LiveSession", () => {
     expect(screen.queryByText(/Rest ·/)).not.toBeInTheDocument();
   });
 
+  it("reorders exercises, keeping the done flag and pointer on the moved one", async () => {
+    const user = userEvent.setup();
+    saveLS(K_WO, [
+      {
+        id: "w2",
+        date: "2026-06-13",
+        name: "Push Day",
+        exercises: [
+          { exerciseName: "Bench", sets: [{ set: 1, weight: 80, reps: 8 }] },
+          { exerciseName: "Squat", sets: [{ set: 1, weight: 100, reps: 5 }] },
+        ],
+      },
+    ]);
+    saveLS(K_SESSION, {
+      workoutId: "w2",
+      startedAt: Date.now(),
+      currentIdx: 0,
+      done: {},
+    });
+    render(
+      <AppProvider>
+        <LiveSession />
+      </AppProvider>,
+    );
+
+    expect(screen.getByText("Exercise 1 of 2")).toBeInTheDocument();
+    // Complete Bench's set, then move Bench later.
+    await user.click(screen.getByRole("button", { name: /Mark set 1 done/i }));
+    await user.click(
+      screen.getByRole("button", { name: /Move exercise later/i }),
+    );
+
+    // The view follows Bench to position 2, and its done flag came along.
+    expect(screen.getByText("Exercise 2 of 2")).toBeInTheDocument();
+    expect(screen.getByText("Bench")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Mark set 1 done/i }),
+    ).toHaveAttribute("aria-pressed", "true");
+  });
+
   it("closes the session when finished", async () => {
     const user = userEvent.setup();
     seedAndRender();

--- a/src/components/LiveSession.test.jsx
+++ b/src/components/LiveSession.test.jsx
@@ -1,0 +1,74 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { AppProvider } from "../context/AppContext";
+import { saveLS, K_WO, K_SESSION } from "../lib/storage";
+import LiveSession from "./LiveSession";
+
+function seedAndRender() {
+  saveLS(K_WO, [
+    {
+      id: "w1",
+      date: "2026-06-13",
+      name: "Push Day",
+      exercises: [
+        { exerciseName: "Bench", sets: [{ set: 1, weight: 80, reps: 8 }] },
+      ],
+    },
+  ]);
+  saveLS(K_SESSION, {
+    workoutId: "w1",
+    startedAt: Date.now(),
+    currentIdx: 0,
+    done: {},
+  });
+  return render(
+    <AppProvider>
+      <LiveSession />
+    </AppProvider>,
+  );
+}
+
+describe("LiveSession", () => {
+  it("renders the current exercise and a sets/elapsed readout", () => {
+    seedAndRender();
+    expect(screen.getByText("Bench")).toBeInTheDocument();
+    expect(screen.getByText(/Exercise 1 of 1/)).toBeInTheDocument();
+    expect(screen.getByText(/0\/1 sets/)).toBeInTheDocument();
+  });
+
+  it("marks a set done and updates the counter", async () => {
+    const user = userEvent.setup();
+    seedAndRender();
+    const doneBtn = screen.getByRole("button", { name: /Mark set 1 done/i });
+    expect(doneBtn).toHaveAttribute("aria-pressed", "false");
+    await user.click(doneBtn);
+    expect(doneBtn).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByText(/1\/1 sets/)).toBeInTheDocument();
+  });
+
+  it("adds a set", async () => {
+    const user = userEvent.setup();
+    seedAndRender();
+    // Two number inputs (weight + reps) before adding.
+    expect(screen.getAllByRole("spinbutton")).toHaveLength(2);
+    await user.click(screen.getByRole("button", { name: /Add set/i }));
+    expect(screen.getAllByRole("spinbutton")).toHaveLength(4);
+  });
+
+  it("starts and skips the manual rest timer", async () => {
+    const user = userEvent.setup();
+    seedAndRender();
+    await user.click(screen.getByRole("button", { name: /Start rest timer/i }));
+    expect(screen.getByText(/Rest ·/)).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Skip" }));
+    expect(screen.queryByText(/Rest ·/)).not.toBeInTheDocument();
+  });
+
+  it("closes the session when finished", async () => {
+    const user = userEvent.setup();
+    seedAndRender();
+    await user.click(screen.getByRole("button", { name: "Finish" }));
+    expect(screen.queryByText("Bench")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/MoreMenu.jsx
+++ b/src/components/MoreMenu.jsx
@@ -1,0 +1,102 @@
+import React, { useState } from "react";
+import { useApp } from "../context/AppContext";
+import Segmented from "./ui/Segmented";
+import Notepad from "./Notepad";
+import DataManagementMenu from "./DataManagementMenu";
+
+/**
+ * "More" destination — a settings hub for everything that doesn't warrant its
+ * own tab: unit preference, the notepad (as a sub-screen), and data
+ * export/import. Theme is shown as a placeholder for the future dark direction.
+ */
+
+function SectionLabel({ children }) {
+  return (
+    <div className="mb-1.5 px-1 text-[10px] uppercase tracking-wide text-neutral-400">
+      {children}
+    </div>
+  );
+}
+
+export default function MoreMenu() {
+  const { unit, setUnit } = useApp();
+  const [view, setView] = useState("menu");
+
+  if (view === "notepad") {
+    return (
+      <div className="space-y-3">
+        <button
+          type="button"
+          onClick={() => setView("menu")}
+          className="flex items-center gap-1 text-sm text-blue-600"
+        >
+          <span aria-hidden>←</span> More
+        </button>
+        <Notepad />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-5">
+      <h1 className="text-xl font-semibold text-neutral-900">More</h1>
+
+      {/* Preferences */}
+      <div>
+        <SectionLabel>Preferences</SectionLabel>
+        <div className="divide-y rounded-xl border bg-white">
+          <div className="flex items-center justify-between px-3 py-3">
+            <span className="text-sm text-neutral-900">Units</span>
+            <Segmented
+              options={[
+                ["kg", "kg"],
+                ["lb", "lb"],
+              ]}
+              value={unit}
+              onChange={setUnit}
+            />
+          </div>
+          <div className="flex items-center justify-between px-3 py-3">
+            <span className="text-sm text-neutral-900">Theme</span>
+            <span className="text-xs text-neutral-400">Light · dark soon</span>
+          </div>
+        </div>
+      </div>
+
+      {/* Content */}
+      <div>
+        <SectionLabel>Content</SectionLabel>
+        <div className="rounded-xl border bg-white">
+          <button
+            type="button"
+            onClick={() => setView("notepad")}
+            className="flex w-full items-center justify-between px-3 py-3 text-left transition hover:bg-neutral-50"
+          >
+            <span className="text-sm text-neutral-900">Notepad</span>
+            <span aria-hidden className="text-neutral-400">
+              ›
+            </span>
+          </button>
+        </div>
+      </div>
+
+      {/* Data */}
+      <div>
+        <SectionLabel>Data</SectionLabel>
+        <div className="flex items-center justify-between rounded-xl border bg-white px-3 py-3">
+          <div>
+            <div className="text-sm text-neutral-900">Backup</div>
+            <div className="text-[11px] text-neutral-500">
+              Export or import your data as JSON
+            </div>
+          </div>
+          <DataManagementMenu />
+        </div>
+      </div>
+
+      <p className="px-1 text-center text-[11px] text-neutral-400">
+        Gym Tracker · data stored in your browser
+      </p>
+    </div>
+  );
+}

--- a/src/components/MoreMenu.jsx
+++ b/src/components/MoreMenu.jsx
@@ -6,20 +6,20 @@ import DataManagementMenu from "./DataManagementMenu";
 
 /**
  * "More" destination — a settings hub for everything that doesn't warrant its
- * own tab: unit preference, the notepad (as a sub-screen), and data
- * export/import. Theme is shown as a placeholder for the future dark direction.
+ * own tab: unit + theme preferences, the notepad (as a sub-screen), and data
+ * export/import.
  */
 
 function SectionLabel({ children }) {
   return (
-    <div className="mb-1.5 px-1 text-[10px] uppercase tracking-wide text-neutral-400">
+    <div className="mb-1.5 px-1 text-[10px] uppercase tracking-wide text-neutral-400 dark:text-neutral-500">
       {children}
     </div>
   );
 }
 
 export default function MoreMenu() {
-  const { unit, setUnit } = useApp();
+  const { unit, setUnit, theme, setTheme } = useApp();
   const [view, setView] = useState("menu");
 
   if (view === "notepad") {
@@ -28,7 +28,7 @@ export default function MoreMenu() {
         <button
           type="button"
           onClick={() => setView("menu")}
-          className="flex items-center gap-1 text-sm text-blue-600"
+          className="flex items-center gap-1 text-sm text-blue-600 dark:text-blue-400"
         >
           <span aria-hidden>←</span> More
         </button>
@@ -37,16 +37,22 @@ export default function MoreMenu() {
     );
   }
 
+  const card =
+    "rounded-xl border bg-white dark:border-neutral-800 dark:bg-neutral-900";
+  const rowText = "text-sm text-neutral-900 dark:text-neutral-100";
+
   return (
     <div className="space-y-5">
-      <h1 className="text-xl font-semibold text-neutral-900">More</h1>
+      <h1 className="text-xl font-semibold text-neutral-900 dark:text-neutral-100">
+        More
+      </h1>
 
       {/* Preferences */}
       <div>
         <SectionLabel>Preferences</SectionLabel>
-        <div className="divide-y rounded-xl border bg-white">
+        <div className={`${card} divide-y dark:divide-neutral-800`}>
           <div className="flex items-center justify-between px-3 py-3">
-            <span className="text-sm text-neutral-900">Units</span>
+            <span className={rowText}>Units</span>
             <Segmented
               options={[
                 ["kg", "kg"],
@@ -57,8 +63,16 @@ export default function MoreMenu() {
             />
           </div>
           <div className="flex items-center justify-between px-3 py-3">
-            <span className="text-sm text-neutral-900">Theme</span>
-            <span className="text-xs text-neutral-400">Light · dark soon</span>
+            <span className={rowText}>Theme</span>
+            <Segmented
+              options={[
+                ["system", "Auto"],
+                ["light", "Light"],
+                ["dark", "Dark"],
+              ]}
+              value={theme}
+              onChange={setTheme}
+            />
           </div>
         </div>
       </div>
@@ -66,14 +80,17 @@ export default function MoreMenu() {
       {/* Content */}
       <div>
         <SectionLabel>Content</SectionLabel>
-        <div className="rounded-xl border bg-white">
+        <div className={card}>
           <button
             type="button"
             onClick={() => setView("notepad")}
-            className="flex w-full items-center justify-between px-3 py-3 text-left transition hover:bg-neutral-50"
+            className="flex w-full items-center justify-between px-3 py-3 text-left transition hover:bg-neutral-50 dark:hover:bg-neutral-800"
           >
-            <span className="text-sm text-neutral-900">Notepad</span>
-            <span aria-hidden className="text-neutral-400">
+            <span className={rowText}>Notepad</span>
+            <span
+              aria-hidden
+              className="text-neutral-400 dark:text-neutral-500"
+            >
               ›
             </span>
           </button>
@@ -83,10 +100,10 @@ export default function MoreMenu() {
       {/* Data */}
       <div>
         <SectionLabel>Data</SectionLabel>
-        <div className="flex items-center justify-between rounded-xl border bg-white px-3 py-3">
+        <div className={`${card} flex items-center justify-between px-3 py-3`}>
           <div>
-            <div className="text-sm text-neutral-900">Backup</div>
-            <div className="text-[11px] text-neutral-500">
+            <div className={rowText}>Backup</div>
+            <div className="text-[11px] text-neutral-500 dark:text-neutral-400">
               Export or import your data as JSON
             </div>
           </div>
@@ -94,7 +111,7 @@ export default function MoreMenu() {
         </div>
       </div>
 
-      <p className="px-1 text-center text-[11px] text-neutral-400">
+      <p className="px-1 text-center text-[11px] text-neutral-400 dark:text-neutral-500">
         Gym Tracker · data stored in your browser
       </p>
     </div>

--- a/src/components/MoreMenu.jsx
+++ b/src/components/MoreMenu.jsx
@@ -19,7 +19,7 @@ function SectionLabel({ children }) {
 }
 
 export default function MoreMenu() {
-  const { unit, setUnit, theme, setTheme } = useApp();
+  const { theme, setTheme } = useApp();
   const [view, setView] = useState("menu");
 
   if (view === "notepad") {
@@ -51,17 +51,15 @@ export default function MoreMenu() {
       <div>
         <SectionLabel>Preferences</SectionLabel>
         <div className={`${card} divide-y dark:divide-neutral-800`}>
-          <div className="flex items-center justify-between px-3 py-3">
-            <span className={rowText}>Units</span>
-            <Segmented
-              options={[
-                ["kg", "kg"],
-                ["lb", "lb"],
-              ]}
-              value={unit}
-              onChange={setUnit}
-            />
-          </div>
+          {/*
+            Units (kg/lb) toggle temporarily hidden: bodyweight logs aren't
+            unit-converted yet (ARCHITECTURE.md open question #1), so switching
+            to lb mislabels bodyweight. Restore this row once that's fixed.
+              <div className="flex items-center justify-between px-3 py-3">
+                <span className={rowText}>Units</span>
+                <Segmented options={[["kg","kg"],["lb","lb"]]} value={unit} onChange={setUnit} />
+              </div>
+          */}
           <div className="flex items-center justify-between px-3 py-3">
             <span className={rowText}>Theme</span>
             <Segmented

--- a/src/components/MoreMenu.test.jsx
+++ b/src/components/MoreMenu.test.jsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { AppProvider } from "../context/AppContext";
+import MoreMenu from "./MoreMenu";
+
+vi.mock("./Notepad", () => ({ default: () => <div>NOTEPAD</div> }));
+vi.mock("./DataManagementMenu", () => ({ default: () => <div>DATA</div> }));
+
+const renderMore = () =>
+  render(
+    <AppProvider>
+      <MoreMenu />
+    </AppProvider>,
+  );
+
+describe("MoreMenu", () => {
+  it("renders the settings sections", () => {
+    renderMore();
+    expect(screen.getByRole("heading", { name: "More" })).toBeInTheDocument();
+    expect(screen.getByText("Units")).toBeInTheDocument();
+    expect(screen.getByText("DATA")).toBeInTheDocument();
+  });
+
+  it("opens the notepad as a sub-screen and returns", async () => {
+    const user = userEvent.setup();
+    renderMore();
+    await user.click(screen.getByRole("button", { name: "Notepad" }));
+    expect(screen.getByText("NOTEPAD")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /More/ }));
+    expect(screen.getByRole("heading", { name: "More" })).toBeInTheDocument();
+  });
+});

--- a/src/components/MoreMenu.test.jsx
+++ b/src/components/MoreMenu.test.jsx
@@ -18,8 +18,13 @@ describe("MoreMenu", () => {
   it("renders the settings sections", () => {
     renderMore();
     expect(screen.getByRole("heading", { name: "More" })).toBeInTheDocument();
-    expect(screen.getByText("Units")).toBeInTheDocument();
+    expect(screen.getByText("Theme")).toBeInTheDocument();
     expect(screen.getByText("DATA")).toBeInTheDocument();
+  });
+
+  it("does not show the units toggle while it is hidden", () => {
+    renderMore();
+    expect(screen.queryByText("Units")).not.toBeInTheDocument();
   });
 
   it("opens the notepad as a sub-screen and returns", async () => {

--- a/src/components/NewExerciseInline.jsx
+++ b/src/components/NewExerciseInline.jsx
@@ -62,7 +62,7 @@ export default function NewExerciseInline({ existing, options, onCreate }) {
   };
 
   return (
-    <div className="mt-3 space-y-2 p-3 rounded-xl border bg-neutral-50">
+    <div className="mt-3 space-y-2 p-3 rounded-xl border dark:border-neutral-800 bg-neutral-50 dark:bg-neutral-800">
       <div className="grid sm:grid-cols-2 gap-2">
         <Input
           placeholder="Exercise name"

--- a/src/components/Notepad.jsx
+++ b/src/components/Notepad.jsx
@@ -49,7 +49,7 @@ export default function Notepad() {
         placeholder="Write your notes here..."
         value={content}
         onChange={(e) => setContent(e.target.value)}
-        className="w-full resize-y overflow-auto border dark:border-neutral-800 rounded p-2"
+        className="w-full resize-y overflow-auto border rounded p-2 bg-white dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100 dark:placeholder-neutral-500"
       />
     </div>
   );

--- a/src/components/Notepad.jsx
+++ b/src/components/Notepad.jsx
@@ -49,7 +49,7 @@ export default function Notepad() {
         placeholder="Write your notes here..."
         value={content}
         onChange={(e) => setContent(e.target.value)}
-        className="w-full resize-y overflow-auto border rounded p-2"
+        className="w-full resize-y overflow-auto border dark:border-neutral-800 rounded p-2"
       />
     </div>
   );

--- a/src/components/PeriodCard.jsx
+++ b/src/components/PeriodCard.jsx
@@ -28,14 +28,14 @@ export default function PeriodCard({
   }, [open, period.key]);
 
   return (
-    <div className="rounded-xl border border-neutral-200 bg-white shadow-sm mb-3 overflow-hidden">
+    <div className="rounded-xl border dark:border-neutral-800 border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 shadow-sm mb-3 overflow-hidden">
       <button
         type="button"
-        className="w-full text-left px-3 py-2 bg-neutral-50 flex items-center justify-between"
+        className="w-full text-left px-3 py-2 bg-neutral-50 dark:bg-neutral-800 flex items-center justify-between"
         onClick={() => setOpen((o) => !o)}
       >
         <div className="font-semibold">{period.label}</div>
-        <div className="text-xs text-neutral-500">
+        <div className="text-xs text-neutral-500 dark:text-neutral-400">
           {open ? "Collapse ▲" : "Expand ▼"}
         </div>
       </button>
@@ -63,29 +63,37 @@ export default function PeriodCard({
           </div>
 
           <div className="grid grid-cols-5 gap-2">
-            <div className="rounded-lg border p-2">
-              <div className="text-xs text-neutral-500">Workouts</div>
+            <div className="rounded-lg border dark:border-neutral-800 p-2">
+              <div className="text-xs text-neutral-500 dark:text-neutral-400">
+                Workouts
+              </div>
               <div className="text-lg font-semibold flex flex-wrap items-baseline gap-x-1">
                 {metrics.frequency}
                 <Delta curr={metrics.frequency} prev={prevMetrics?.frequency} />
               </div>
             </div>
-            <div className="rounded-lg border p-2">
-              <div className="text-xs text-neutral-500">Total&nbsp;Reps</div>
+            <div className="rounded-lg border dark:border-neutral-800 p-2">
+              <div className="text-xs text-neutral-500 dark:text-neutral-400">
+                Total&nbsp;Reps
+              </div>
               <div className="text-lg font-semibold tabular-nums flex flex-wrap items-baseline gap-x-1">
                 {metrics.totalReps}
                 <Delta curr={metrics.totalReps} prev={prevMetrics?.totalReps} />
               </div>
             </div>
-            <div className="rounded-lg border p-2">
-              <div className="text-xs text-neutral-500">Total&nbsp;Sets</div>
+            <div className="rounded-lg border dark:border-neutral-800 p-2">
+              <div className="text-xs text-neutral-500 dark:text-neutral-400">
+                Total&nbsp;Sets
+              </div>
               <div className="text-lg font-semibold tabular-nums flex flex-wrap items-baseline gap-x-1">
                 {metrics.totalSets}
                 <Delta curr={metrics.totalSets} prev={prevMetrics?.totalSets} />
               </div>
             </div>
-            <div className="rounded-lg border p-2">
-              <div className="text-xs text-neutral-500">New&nbsp;PRs</div>
+            <div className="rounded-lg border dark:border-neutral-800 p-2">
+              <div className="text-xs text-neutral-500 dark:text-neutral-400">
+                New&nbsp;PRs
+              </div>
               <div className="text-lg font-semibold flex flex-wrap items-baseline gap-x-1">
                 {metrics.prs.length}
                 <Delta
@@ -95,8 +103,8 @@ export default function PeriodCard({
               </div>
             </div>
             {isWeek ? (
-              <div className="rounded-lg border p-2">
-                <div className="text-xs text-neutral-500">
+              <div className="rounded-lg border dark:border-neutral-800 p-2">
+                <div className="text-xs text-neutral-500 dark:text-neutral-400">
                   Avg&nbsp;Weight (This&nbsp;Week)
                 </div>
                 <div className="text-lg font-semibold tabular-nums flex flex-wrap items-baseline gap-x-1">
@@ -109,9 +117,13 @@ export default function PeriodCard({
                 </div>
               </div>
             ) : (
-              <div className="rounded-lg border p-2 opacity-50">
-                <div className="text-xs text-neutral-400">Avg&nbsp;Weight</div>
-                <div className="text-lg font-semibold text-neutral-400">—</div>
+              <div className="rounded-lg border dark:border-neutral-800 p-2 opacity-50">
+                <div className="text-xs text-neutral-400 dark:text-neutral-500">
+                  Avg&nbsp;Weight
+                </div>
+                <div className="text-lg font-semibold text-neutral-400 dark:text-neutral-500">
+                  —
+                </div>
               </div>
             )}
           </div>
@@ -119,14 +131,14 @@ export default function PeriodCard({
           {metrics.prs.length > 0 ? (
             <div className="space-y-1">
               <div className="text-sm font-medium">New PRs this period</div>
-              <div className="text-sm border rounded-lg divide-y">
+              <div className="text-sm border dark:border-neutral-800 rounded-lg divide-y dark:divide-neutral-800">
                 {metrics.prs.map((p) => (
                   <div
                     key={p.exercise}
                     className="flex items-center justify-between px-2 py-1"
                   >
                     <div className="font-medium">{p.exercise}</div>
-                    <div className="text-xs text-neutral-600">
+                    <div className="text-xs text-neutral-600 dark:text-neutral-300">
                       {p.prevBest} →{" "}
                       <span className="font-semibold">{p.newBest}</span>
                     </div>
@@ -135,7 +147,7 @@ export default function PeriodCard({
               </div>
             </div>
           ) : (
-            <div className="text-sm text-neutral-500">
+            <div className="text-sm text-neutral-500 dark:text-neutral-400">
               No new PRs this period.
             </div>
           )}

--- a/src/components/Progress.jsx
+++ b/src/components/Progress.jsx
@@ -14,7 +14,9 @@ export default function Progress() {
   return (
     <div className="space-y-4">
       <div className="flex items-center justify-between">
-        <h1 className="text-xl font-semibold text-neutral-900">Progress</h1>
+        <h1 className="text-xl font-semibold text-neutral-900 dark:text-neutral-100">
+          Progress
+        </h1>
         <Segmented
           options={[
             ["bodyweight", "Bodyweight"],

--- a/src/components/Progress.jsx
+++ b/src/components/Progress.jsx
@@ -1,0 +1,31 @@
+import React, { useState } from "react";
+import Segmented from "./ui/Segmented";
+import WeightTracker from "./WeightTracker";
+import DashboardSummary from "./DashboardSummary";
+
+/**
+ * Progress destination. Merges the former Weight and Summary tabs:
+ * "Bodyweight" shows the bodyweight calendar + trend, "Strength" shows the
+ * per-period workout analytics.
+ */
+export default function Progress() {
+  const [view, setView] = useState("bodyweight");
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h1 className="text-xl font-semibold text-neutral-900">Progress</h1>
+        <Segmented
+          options={[
+            ["bodyweight", "Bodyweight"],
+            ["strength", "Strength"],
+          ]}
+          value={view}
+          onChange={setView}
+        />
+      </div>
+
+      {view === "bodyweight" ? <WeightTracker /> : <DashboardSummary />}
+    </div>
+  );
+}

--- a/src/components/Progress.test.jsx
+++ b/src/components/Progress.test.jsx
@@ -1,0 +1,23 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import Progress from "./Progress";
+
+vi.mock("./WeightTracker", () => ({ default: () => <div>WEIGHT</div> }));
+vi.mock("./DashboardSummary", () => ({ default: () => <div>SUMMARY</div> }));
+
+describe("Progress", () => {
+  it("shows bodyweight by default", () => {
+    render(<Progress />);
+    expect(screen.getByText("WEIGHT")).toBeInTheDocument();
+    expect(screen.queryByText("SUMMARY")).not.toBeInTheDocument();
+  });
+
+  it("switches to strength analytics via the toggle", async () => {
+    const user = userEvent.setup();
+    render(<Progress />);
+    await user.click(screen.getByRole("button", { name: "Strength" }));
+    expect(screen.getByText("SUMMARY")).toBeInTheDocument();
+    expect(screen.queryByText("WEIGHT")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/RpeFeedback.jsx
+++ b/src/components/RpeFeedback.jsx
@@ -34,7 +34,7 @@ export default function RpeFeedback({
 
   const rpeBadge =
     rpe != null ? (
-      <span className="shrink-0 rounded-xl border border-cyan-300 bg-cyan-50 px-2 py-0.5 text-xs font-medium text-cyan-800">
+      <span className="shrink-0 rounded-xl border dark:border-neutral-800 border-cyan-300 bg-cyan-50 px-2 py-0.5 text-xs font-medium text-cyan-800">
         RPE {rpe}
       </span>
     ) : null;
@@ -45,7 +45,7 @@ export default function RpeFeedback({
       <div className="flex items-start gap-2">
         {rpeBadge}
         {feedback.trim() !== "" && (
-          <span className="whitespace-pre-wrap text-sm text-neutral-600">
+          <span className="whitespace-pre-wrap text-sm text-neutral-600 dark:text-neutral-300">
             {feedback}
           </span>
         )}
@@ -60,7 +60,7 @@ export default function RpeFeedback({
         <button
           type="button"
           onClick={() => setOpen(true)}
-          className="inline-flex items-center gap-1 text-xs text-neutral-600 hover:text-neutral-900"
+          className="inline-flex items-center gap-1 text-xs text-neutral-600 dark:text-neutral-300 hover:text-neutral-900"
         >
           <Plus /> RPE / note
         </button>
@@ -70,13 +70,15 @@ export default function RpeFeedback({
       <button
         type="button"
         onClick={() => setOpen(true)}
-        className="flex max-w-full items-center gap-2 rounded-xl border px-2.5 py-1.5 text-left hover:bg-neutral-50"
+        className="flex max-w-full items-center gap-2 rounded-xl border dark:border-neutral-800 px-2.5 py-1.5 text-left hover:bg-neutral-50 dark:hover:bg-neutral-800"
       >
         {rpeBadge}
         {feedback.trim() !== "" && (
-          <span className="truncate text-sm text-neutral-600">{feedback}</span>
+          <span className="truncate text-sm text-neutral-600 dark:text-neutral-300">
+            {feedback}
+          </span>
         )}
-        <span className="ml-auto shrink-0 text-neutral-400">
+        <span className="ml-auto shrink-0 text-neutral-400 dark:text-neutral-500">
           <Pencil />
         </span>
       </button>
@@ -87,12 +89,15 @@ export default function RpeFeedback({
   return (
     <div className="space-y-2 border-t border-dashed pt-2">
       <div className="flex items-center gap-2">
-        <label className="w-9 text-xs text-neutral-600" htmlFor="rpe-select">
+        <label
+          className="w-9 text-xs text-neutral-600 dark:text-neutral-300"
+          htmlFor="rpe-select"
+        >
           RPE
         </label>
         <select
           id="rpe-select"
-          className="rounded-xl border px-2 py-1.5 text-sm"
+          className="rounded-xl border dark:border-neutral-800 px-2 py-1.5 text-sm"
           value={rpe == null ? "" : String(rpe)}
           onChange={(e) =>
             onChange({
@@ -107,7 +112,9 @@ export default function RpeFeedback({
             </option>
           ))}
         </select>
-        <span className="text-xs text-neutral-400">optional</span>
+        <span className="text-xs text-neutral-400 dark:text-neutral-500">
+          optional
+        </span>
         <Button
           variant="ghost"
           size="sm"

--- a/src/components/WeeklyNotes.jsx
+++ b/src/components/WeeklyNotes.jsx
@@ -163,11 +163,13 @@ export default function WeeklyNotes({ periodKey }) {
       </div>
 
       {!editing ? (
-        <div className="text-sm whitespace-pre-wrap text-neutral-800">
+        <div className="text-sm whitespace-pre-wrap text-neutral-800 dark:text-neutral-200">
           {saved ? (
             saved
           ) : (
-            <span className="text-neutral-500">No notes yet.</span>
+            <span className="text-neutral-500 dark:text-neutral-400">
+              No notes yet.
+            </span>
           )}
         </div>
       ) : (
@@ -175,7 +177,7 @@ export default function WeeklyNotes({ periodKey }) {
           <textarea
             ref={textareaRef}
             id={`weekly-note-ta-${periodKey}`}
-            className="w-full min-h-[96px] resize-none rounded-lg border border-neutral-300 p-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            className="w-full min-h-[96px] resize-none rounded-lg border dark:border-neutral-800 border-neutral-300 dark:border-neutral-700 p-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
             placeholder="How did you feel this week? Sleep, stress, pumps, soreness…"
             value={draft}
             onChange={(e) => setDraft(e.target.value)}

--- a/src/components/WeeklyNotes.jsx
+++ b/src/components/WeeklyNotes.jsx
@@ -177,7 +177,7 @@ export default function WeeklyNotes({ periodKey }) {
           <textarea
             ref={textareaRef}
             id={`weekly-note-ta-${periodKey}`}
-            className="w-full min-h-[96px] resize-none rounded-lg border dark:border-neutral-800 border-neutral-300 dark:border-neutral-700 p-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            className="w-full min-h-[96px] resize-none rounded-lg border border-neutral-300 dark:border-neutral-700 bg-white dark:bg-neutral-900 dark:text-neutral-100 dark:placeholder-neutral-500 p-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
             placeholder="How did you feel this week? Sleep, stress, pumps, soreness…"
             value={draft}
             onChange={(e) => setDraft(e.target.value)}

--- a/src/components/WeightChart.jsx
+++ b/src/components/WeightChart.jsx
@@ -10,7 +10,9 @@ import { buildWeightSeries } from "../lib/weightSeries";
 function SimpleLineChart({ points, height = 200, width = 720, padding = 32 }) {
   if (!points || points.length < 2) {
     return (
-      <div className="text-sm text-neutral-500">Not enough data to plot.</div>
+      <div className="text-sm text-neutral-500 dark:text-neutral-400">
+        Not enough data to plot.
+      </div>
     );
   }
   const ys = points.map((p) => p.y);

--- a/src/components/WeightRepInputs.jsx
+++ b/src/components/WeightRepInputs.jsx
@@ -24,7 +24,7 @@ export default function WeightRepInputs({
         <NumberInputAutoClear
           step="0.5"
           min="0"
-          className="border rounded-xl px-3 py-1.5 text-sm w-16"
+          className="border dark:border-neutral-800 rounded-xl px-3 py-1.5 text-sm w-16"
           valueNumber={weight}
           onNumberChange={onWeightChange}
         />
@@ -33,7 +33,7 @@ export default function WeightRepInputs({
         <NumberInputAutoClear
           step="1"
           min="0"
-          className="border rounded-xl px-3 py-1.5 text-sm w-16"
+          className="border dark:border-neutral-800 rounded-xl px-3 py-1.5 text-sm w-16"
           valueNumber={reps}
           onNumberChange={onRepsChange}
         />

--- a/src/components/WeightRepInputs.jsx
+++ b/src/components/WeightRepInputs.jsx
@@ -24,7 +24,7 @@ export default function WeightRepInputs({
         <NumberInputAutoClear
           step="0.5"
           min="0"
-          className="border dark:border-neutral-800 rounded-xl px-3 py-1.5 text-sm w-16"
+          className="border rounded-xl px-3 py-1.5 text-sm w-16 bg-white dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100"
           valueNumber={weight}
           onNumberChange={onWeightChange}
         />
@@ -33,7 +33,7 @@ export default function WeightRepInputs({
         <NumberInputAutoClear
           step="1"
           min="0"
-          className="border dark:border-neutral-800 rounded-xl px-3 py-1.5 text-sm w-16"
+          className="border rounded-xl px-3 py-1.5 text-sm w-16 bg-white dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100"
           valueNumber={reps}
           onNumberChange={onRepsChange}
         />

--- a/src/components/WeightTracker.jsx
+++ b/src/components/WeightTracker.jsx
@@ -141,7 +141,10 @@ export default function WeightTracker() {
       {/* Calendar grid */}
       <div className="grid grid-cols-7 gap-1 text-xs">
         {["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"].map((d) => (
-          <div key={d} className="text-center text-neutral-500 py-1">
+          <div
+            key={d}
+            className="text-center text-neutral-500 dark:text-neutral-400 py-1"
+          >
             {d}
           </div>
         ))}
@@ -155,13 +158,15 @@ export default function WeightTracker() {
             <div
               key={key}
               className={[
-                "relative h-16 border rounded-md p-1 cursor-pointer",
-                inMonth ? "bg-white" : "bg-neutral-50",
+                "relative h-16 border dark:border-neutral-800 rounded-md p-1 cursor-pointer",
+                inMonth
+                  ? "bg-white dark:bg-neutral-900"
+                  : "bg-neutral-50 dark:bg-neutral-800",
                 isToday ? "ring-2 ring-blue-500" : "",
               ].join(" ")}
               onClick={() => onCellClick(d)}
             >
-              <div className="absolute top-1 left-1 text-[10px] text-neutral-500">
+              <div className="absolute top-1 left-1 text-[10px] text-neutral-500 dark:text-neutral-400">
                 {d.getDate()}
               </div>
               {editingKey === key ? (
@@ -170,7 +175,7 @@ export default function WeightTracker() {
                     autoFocus
                     type="number"
                     step="0.1"
-                    className="w-full text-center border rounded px-2 py-1 text-sm"
+                    className="w-full text-center border dark:border-neutral-800 rounded px-2 py-1 text-sm"
                     value={draft}
                     onChange={(e) => setDraft(e.target.value)}
                     onBlur={commitEdit}
@@ -185,7 +190,10 @@ export default function WeightTracker() {
                   {/* Smaller weight text so it doesn't cover the date */}
                   <div className="text-[10px] md:text-xs font-semibold">
                     {val}
-                    <span className="text-[9px] text-neutral-500"> {unit}</span>
+                    <span className="text-[9px] text-neutral-500 dark:text-neutral-400">
+                      {" "}
+                      {unit}
+                    </span>
                   </div>
                 </div>
               ) : null}
@@ -195,20 +203,24 @@ export default function WeightTracker() {
       </div>
 
       {/* Weekly average + delta */}
-      <div className="rounded-lg border p-3 grid grid-cols-2 gap-3">
+      <div className="rounded-lg border dark:border-neutral-800 p-3 grid grid-cols-2 gap-3">
         <div>
-          <div className="text-xs text-neutral-500">This Week Avg</div>
+          <div className="text-xs text-neutral-500 dark:text-neutral-400">
+            This Week Avg
+          </div>
           <div className="text-lg font-semibold">
             {weekAvg != null ? `${weekAvg} ${unit}` : "—"}
           </div>
         </div>
         <div>
-          <div className="text-xs text-neutral-500">Δ vs Last Week</div>
+          <div className="text-xs text-neutral-500 dark:text-neutral-400">
+            Δ vs Last Week
+          </div>
           <div
             className={[
               "text-lg font-semibold",
               weekDelta == null
-                ? "text-neutral-400"
+                ? "text-neutral-400 dark:text-neutral-500"
                 : weekDelta > 0
                   ? "text-green-600"
                   : "text-red-600",
@@ -260,20 +272,22 @@ export default function WeightTracker() {
         {period === "custom" && (
           <div className="flex flex-wrap items-center gap-2 text-sm">
             <label className="flex items-center gap-1">
-              <span className="text-neutral-500">From</span>
+              <span className="text-neutral-500 dark:text-neutral-400">
+                From
+              </span>
               <input
                 type="date"
-                className="border rounded px-2 py-1"
+                className="border dark:border-neutral-800 rounded px-2 py-1"
                 value={customFrom}
                 max={customTo || todayYmd}
                 onChange={(e) => setCustomFrom(e.target.value)}
               />
             </label>
             <label className="flex items-center gap-1">
-              <span className="text-neutral-500">To</span>
+              <span className="text-neutral-500 dark:text-neutral-400">To</span>
               <input
                 type="date"
-                className="border rounded px-2 py-1"
+                className="border dark:border-neutral-800 rounded px-2 py-1"
                 value={customTo}
                 min={customFrom || undefined}
                 onChange={(e) => setCustomTo(e.target.value)}
@@ -289,9 +303,9 @@ export default function WeightTracker() {
           filled days per ISO week. Passing the logs ensures it uses the same
           data that WeightTracker manages.
         */}
-        <div className="rounded-lg border p-3">
+        <div className="rounded-lg border dark:border-neutral-800 p-3">
           {period === "custom" && !customFrom ? (
-            <div className="text-sm text-neutral-500">
+            <div className="text-sm text-neutral-500 dark:text-neutral-400">
               Pick a start date to plot a custom range.
             </div>
           ) : (

--- a/src/components/WeightTracker.jsx
+++ b/src/components/WeightTracker.jsx
@@ -175,7 +175,7 @@ export default function WeightTracker() {
                     autoFocus
                     type="number"
                     step="0.1"
-                    className="w-full text-center border dark:border-neutral-800 rounded px-2 py-1 text-sm"
+                    className="w-full text-center border rounded px-2 py-1 text-sm bg-white dark:border-neutral-700 dark:bg-neutral-800 dark:text-neutral-100"
                     value={draft}
                     onChange={(e) => setDraft(e.target.value)}
                     onBlur={commitEdit}
@@ -277,7 +277,7 @@ export default function WeightTracker() {
               </span>
               <input
                 type="date"
-                className="border dark:border-neutral-800 rounded px-2 py-1"
+                className="border rounded px-2 py-1 bg-white dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100 dark:[color-scheme:dark]"
                 value={customFrom}
                 max={customTo || todayYmd}
                 onChange={(e) => setCustomFrom(e.target.value)}
@@ -287,7 +287,7 @@ export default function WeightTracker() {
               <span className="text-neutral-500 dark:text-neutral-400">To</span>
               <input
                 type="date"
-                className="border dark:border-neutral-800 rounded px-2 py-1"
+                className="border rounded px-2 py-1 bg-white dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100 dark:[color-scheme:dark]"
                 value={customTo}
                 min={customFrom || undefined}
                 onChange={(e) => setCustomTo(e.target.value)}

--- a/src/components/WorkoutExerciseEditor.jsx
+++ b/src/components/WorkoutExerciseEditor.jsx
@@ -57,7 +57,7 @@ export default function WorkoutExerciseEditor({
   };
 
   return (
-    <div className="relative rounded-2xl border p-3 overflow-hidden">
+    <div className="relative rounded-2xl border dark:border-neutral-800 p-3 overflow-hidden">
       {/* cyan accent bar for the whole exercise */}
       <div className="absolute inset-y-0 left-0 w-1 bg-cyan-300"></div>
       <div className="mb-2 flex items-center justify-between">
@@ -70,7 +70,7 @@ export default function WorkoutExerciseEditor({
             {item.exerciseName}
           </span>
           {recommendRep ? (
-            <span className="ml-2 text-xs text-neutral-500">
+            <span className="ml-2 text-xs text-neutral-500 dark:text-neutral-400">
               ({recommendRep})
             </span>
           ) : null}
@@ -102,7 +102,7 @@ export default function WorkoutExerciseEditor({
       </div>
 
       {/* Header row for sets */}
-      <div className="flex items-center gap-3 px-3 py-1 text-xs text-neutral-500">
+      <div className="flex items-center gap-3 px-3 py-1 text-xs text-neutral-500 dark:text-neutral-400">
         <span className="w-16" />
         <div className="flex-1 grid grid-cols-2 gap-3">
           <div>Weight ({unit})</div>
@@ -116,11 +116,13 @@ export default function WorkoutExerciseEditor({
         {sets.map((s, idx) => (
           <div
             key={idx}
-            className="relative flex items-center gap-3 rounded-xl border px-3 py-2 shadow-sm overflow-hidden"
+            className="relative flex items-center gap-3 rounded-xl border dark:border-neutral-800 px-3 py-2 shadow-sm overflow-hidden"
           >
             {/* cyan accent bar for each set */}
             <div className="absolute inset-y-0 left-0 w-1 bg-cyan-200"></div>
-            <span className="w-16 text-sm text-neutral-600">Set {idx + 1}</span>
+            <span className="w-16 text-sm text-neutral-600 dark:text-neutral-300">
+              Set {idx + 1}
+            </span>
             <WeightRepInputs
               weight={toDisplayWeight(s.weight, unit)}
               reps={s.reps}

--- a/src/components/WorkoutHistory.jsx
+++ b/src/components/WorkoutHistory.jsx
@@ -52,11 +52,13 @@ export default function WorkoutHistory() {
 
   return (
     <div className="mt-4 space-y-3">
-      <h3 className="text-sm font-semibold uppercase tracking-wide text-neutral-600">
+      <h3 className="text-sm font-semibold uppercase tracking-wide text-neutral-600 dark:text-neutral-300">
         History
       </h3>
       {workouts.length === 0 && (
-        <p className="text-sm text-neutral-500">No workouts logged yet.</p>
+        <p className="text-sm text-neutral-500 dark:text-neutral-400">
+          No workouts logged yet.
+        </p>
       )}
       {workouts.map((w) => (
         <WorkoutHistoryItem

--- a/src/components/WorkoutHistoryItem.jsx
+++ b/src/components/WorkoutHistoryItem.jsx
@@ -43,11 +43,13 @@ export default function WorkoutHistoryItem({
   const confirm = useConfirm();
 
   return (
-    <div className="rounded-2xl border">
+    <div className="rounded-2xl border dark:border-neutral-800">
       <div className="flex items-center justify-between px-4 py-3">
         <div>
           <div className="text-base font-medium">{w.name}</div>
-          <div className="text-xs text-neutral-600">{w.date}</div>
+          <div className="text-xs text-neutral-600 dark:text-neutral-300">
+            {w.date}
+          </div>
         </div>
         <div className="flex items-center gap-2">
           <Button variant="secondary" onClick={onToggle}>
@@ -75,7 +77,9 @@ export default function WorkoutHistoryItem({
         <div className="space-y-3 p-4 border-t">
           <div className="grid grid-cols-2 gap-2">
             <div className="space-y-1">
-              <label className="text-xs text-neutral-600">Date</label>
+              <label className="text-xs text-neutral-600 dark:text-neutral-300">
+                Date
+              </label>
               <Input
                 type="date"
                 value={w.date}
@@ -83,7 +87,9 @@ export default function WorkoutHistoryItem({
               />
             </div>
             <div className="space-y-1">
-              <label className="text-xs text-neutral-600">Workout name</label>
+              <label className="text-xs text-neutral-600 dark:text-neutral-300">
+                Workout name
+              </label>
               <Input
                 value={w.name}
                 onChange={(e) =>
@@ -100,7 +106,7 @@ export default function WorkoutHistoryItem({
             {w.exercises.map((we, idx) => (
               <div
                 key={idx}
-                className="relative rounded-xl border p-3 overflow-hidden"
+                className="relative rounded-xl border dark:border-neutral-800 p-3 overflow-hidden"
               >
                 {/* cyan accent bar for each exercise */}
                 <div className="absolute inset-y-0 left-0 w-1 bg-cyan-300"></div>
@@ -117,7 +123,7 @@ export default function WorkoutHistoryItem({
                         exercises.find((e) => e.name === we.exerciseName)
                           ?.recommendRep || "";
                       return rec ? (
-                        <span className="ml-2 text-xs text-neutral-500">
+                        <span className="ml-2 text-xs text-neutral-500 dark:text-neutral-400">
                           ({rec})
                         </span>
                       ) : null;
@@ -182,7 +188,7 @@ export default function WorkoutHistoryItem({
                 </div>
 
                 <div className="grid gap-2">
-                  <div className="flex items-center gap-3 px-3 py-1 text-xs text-neutral-500">
+                  <div className="flex items-center gap-3 px-3 py-1 text-xs text-neutral-500 dark:text-neutral-400">
                     <span className="w-16" />
                     <div className="flex-1 grid grid-cols-2 gap-3">
                       <div>Weight ({unit})</div>
@@ -194,11 +200,11 @@ export default function WorkoutHistoryItem({
                   {we.sets.map((s, sidx) => (
                     <div
                       key={sidx}
-                      className="relative flex items-center gap-3 rounded-xl border px-3 py-2 shadow-sm overflow-hidden"
+                      className="relative flex items-center gap-3 rounded-xl border dark:border-neutral-800 px-3 py-2 shadow-sm overflow-hidden"
                     >
                       {/* cyan accent bar for each set */}
                       <div className="absolute inset-y-0 left-0 w-1 bg-cyan-200"></div>
-                      <span className="w-16 text-sm text-neutral-600">
+                      <span className="w-16 text-sm text-neutral-600 dark:text-neutral-300">
                         Set {sidx + 1}
                       </span>
                       <WeightRepInputs
@@ -320,7 +326,7 @@ export default function WorkoutHistoryItem({
           </div>
 
           {/* Add exercise input moved below the list */}
-          <div className="rounded-xl border p-3">
+          <div className="rounded-xl border dark:border-neutral-800 p-3">
             <div className="mb-2 font-medium text-sm">
               Add exercise to this workout
             </div>

--- a/src/components/WorkoutHistoryItem.jsx
+++ b/src/components/WorkoutHistoryItem.jsx
@@ -7,6 +7,7 @@ import WeightRepInputs from "./WeightRepInputs";
 import RpeFeedback from "./RpeFeedback";
 import { fromDisplayWeight, toDisplayWeight } from "../lib/units";
 import { useConfirm } from "./ConfirmDialog";
+import { useApp } from "../context/AppContext";
 import { MAX_SETS } from "../lib/constants";
 
 /**
@@ -41,6 +42,7 @@ export default function WorkoutHistoryItem({
   onShowHistory,
 }) {
   const confirm = useConfirm();
+  const { startSession } = useApp();
 
   return (
     <div className="rounded-2xl border dark:border-neutral-800">
@@ -52,6 +54,9 @@ export default function WorkoutHistoryItem({
           </div>
         </div>
         <div className="flex items-center gap-2">
+          <Button variant="primary" onClick={() => startSession(w.id)}>
+            ▶ Start
+          </Button>
           <Button variant="secondary" onClick={onToggle}>
             Details <ChevronDown open={expanded} />
           </Button>

--- a/src/components/WorkoutPlanner.jsx
+++ b/src/components/WorkoutPlanner.jsx
@@ -88,7 +88,9 @@ export default function WorkoutPlanner({ onCreated }) {
         <div className="grid gap-3">
           {/* Date inputs */}
           <div className="space-y-2">
-            <label className="text-xs text-neutral-600">Workout date(s)</label>
+            <label className="text-xs text-neutral-600 dark:text-neutral-300">
+              Workout date(s)
+            </label>
             {dates.map((d, idx) => (
               <div key={idx} className="flex items-center gap-2">
                 <Input
@@ -120,7 +122,7 @@ export default function WorkoutPlanner({ onCreated }) {
 
           {/* Workout name */}
           <div className="space-y-1">
-            <label className="text-xs text-neutral-600">
+            <label className="text-xs text-neutral-600 dark:text-neutral-300">
               Workout name (optional)
             </label>
             <Input
@@ -133,7 +135,7 @@ export default function WorkoutPlanner({ onCreated }) {
           {/* Exercises list */}
           <div className="space-y-2">
             {items.length === 0 && (
-              <p className="text-sm text-neutral-500">
+              <p className="text-sm text-neutral-500 dark:text-neutral-400">
                 No exercises added yet.
               </p>
             )}

--- a/src/components/WorkoutsTab.jsx
+++ b/src/components/WorkoutsTab.jsx
@@ -1,0 +1,38 @@
+import React, { useState } from "react";
+import Segmented from "./ui/Segmented";
+import WorkoutPlanner from "./WorkoutPlanner";
+import WorkoutHistory from "./WorkoutHistory";
+import CalendarView from "./CalendarView";
+
+/**
+ * Workouts destination. Holds the planner + history list ("List"), with the
+ * old Calendar tab folded in as a toggle ("Calendar").
+ */
+export default function WorkoutsTab() {
+  const [view, setView] = useState("list");
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h1 className="text-xl font-semibold text-neutral-900">Workouts</h1>
+        <Segmented
+          options={[
+            ["list", "List"],
+            ["calendar", "Calendar"],
+          ]}
+          value={view}
+          onChange={setView}
+        />
+      </div>
+
+      {view === "list" ? (
+        <>
+          <WorkoutPlanner />
+          <WorkoutHistory />
+        </>
+      ) : (
+        <CalendarView />
+      )}
+    </div>
+  );
+}

--- a/src/components/WorkoutsTab.jsx
+++ b/src/components/WorkoutsTab.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import Segmented from "./ui/Segmented";
+import { useApp } from "../context/AppContext";
 import WorkoutPlanner from "./WorkoutPlanner";
 import WorkoutHistory from "./WorkoutHistory";
 import CalendarView from "./CalendarView";
@@ -10,6 +11,7 @@ import CalendarView from "./CalendarView";
  */
 export default function WorkoutsTab() {
   const [view, setView] = useState("list");
+  const { startEmptyWorkout } = useApp();
 
   return (
     <div className="space-y-4">
@@ -29,6 +31,13 @@ export default function WorkoutsTab() {
 
       {view === "list" ? (
         <>
+          <button
+            type="button"
+            onClick={startEmptyWorkout}
+            className="w-full rounded-xl bg-blue-600 py-2.5 text-sm font-medium text-white transition hover:bg-blue-700"
+          >
+            ▶ Start empty workout
+          </button>
           <WorkoutPlanner />
           <WorkoutHistory />
         </>

--- a/src/components/WorkoutsTab.jsx
+++ b/src/components/WorkoutsTab.jsx
@@ -14,7 +14,9 @@ export default function WorkoutsTab() {
   return (
     <div className="space-y-4">
       <div className="flex items-center justify-between">
-        <h1 className="text-xl font-semibold text-neutral-900">Workouts</h1>
+        <h1 className="text-xl font-semibold text-neutral-900 dark:text-neutral-100">
+          Workouts
+        </h1>
         <Segmented
           options={[
             ["list", "List"],

--- a/src/components/WorkoutsTab.test.jsx
+++ b/src/components/WorkoutsTab.test.jsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import WorkoutsTab from "./WorkoutsTab";
+
+vi.mock("./WorkoutPlanner", () => ({ default: () => <div>PLANNER</div> }));
+vi.mock("./WorkoutHistory", () => ({ default: () => <div>HISTORY</div> }));
+vi.mock("./CalendarView", () => ({ default: () => <div>CALENDAR</div> }));
+
+describe("WorkoutsTab", () => {
+  it("shows the planner + history list by default", () => {
+    render(<WorkoutsTab />);
+    expect(screen.getByText("PLANNER")).toBeInTheDocument();
+    expect(screen.getByText("HISTORY")).toBeInTheDocument();
+    expect(screen.queryByText("CALENDAR")).not.toBeInTheDocument();
+  });
+
+  it("switches to the calendar view via the toggle", async () => {
+    const user = userEvent.setup();
+    render(<WorkoutsTab />);
+    await user.click(screen.getByRole("button", { name: "Calendar" }));
+    expect(screen.getByText("CALENDAR")).toBeInTheDocument();
+    expect(screen.queryByText("PLANNER")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/WorkoutsTab.test.jsx
+++ b/src/components/WorkoutsTab.test.jsx
@@ -1,15 +1,23 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { AppProvider } from "../context/AppContext";
 import WorkoutsTab from "./WorkoutsTab";
 
 vi.mock("./WorkoutPlanner", () => ({ default: () => <div>PLANNER</div> }));
 vi.mock("./WorkoutHistory", () => ({ default: () => <div>HISTORY</div> }));
 vi.mock("./CalendarView", () => ({ default: () => <div>CALENDAR</div> }));
 
+const renderTab = () =>
+  render(
+    <AppProvider>
+      <WorkoutsTab />
+    </AppProvider>,
+  );
+
 describe("WorkoutsTab", () => {
   it("shows the planner + history list by default", () => {
-    render(<WorkoutsTab />);
+    renderTab();
     expect(screen.getByText("PLANNER")).toBeInTheDocument();
     expect(screen.getByText("HISTORY")).toBeInTheDocument();
     expect(screen.queryByText("CALENDAR")).not.toBeInTheDocument();
@@ -17,7 +25,7 @@ describe("WorkoutsTab", () => {
 
   it("switches to the calendar view via the toggle", async () => {
     const user = userEvent.setup();
-    render(<WorkoutsTab />);
+    renderTab();
     await user.click(screen.getByRole("button", { name: "Calendar" }));
     expect(screen.getByText("CALENDAR")).toBeInTheDocument();
     expect(screen.queryByText("PLANNER")).not.toBeInTheDocument();

--- a/src/components/ui/Badge.jsx
+++ b/src/components/ui/Badge.jsx
@@ -1,7 +1,9 @@
 import React from "react";
 export function Badge({ children, className = "" }) {
   return (
-    <span className={`px-2 py-0.5 text-xs border rounded-xl ${className}`}>
+    <span
+      className={`px-2 py-0.5 text-xs border dark:border-neutral-800 rounded-xl ${className}`}
+    >
       {children}
     </span>
   );

--- a/src/components/ui/BottomNav.jsx
+++ b/src/components/ui/BottomNav.jsx
@@ -44,7 +44,7 @@ export default function BottomNav({ active, onSelect }) {
   return (
     <nav
       aria-label="Primary"
-      className="fixed inset-x-0 bottom-0 z-20 border-t border-neutral-200 bg-white/95 backdrop-blur"
+      className="fixed inset-x-0 bottom-0 z-20 border-t border-neutral-200 bg-white/95 backdrop-blur dark:border-neutral-800 dark:bg-neutral-900/95"
     >
       <div className="mx-auto flex max-w-3xl">
         {TABS.map(([key, label]) => {
@@ -58,8 +58,8 @@ export default function BottomNav({ active, onSelect }) {
               className={[
                 "flex flex-1 flex-col items-center gap-0.5 py-2 pb-[max(0.5rem,env(safe-area-inset-bottom))] text-[11px] transition",
                 isActive
-                  ? "text-blue-600"
-                  : "text-neutral-500 hover:text-neutral-800",
+                  ? "text-blue-600 dark:text-blue-400"
+                  : "text-neutral-500 hover:text-neutral-800 dark:text-neutral-400 dark:hover:text-neutral-200",
               ].join(" ")}
             >
               <NavIcon name={key} />

--- a/src/components/ui/BottomNav.jsx
+++ b/src/components/ui/BottomNav.jsx
@@ -1,0 +1,73 @@
+import React from "react";
+
+/**
+ * Fixed bottom tab bar — the app's primary navigation. Five thumb-reachable
+ * destinations, always visible, replacing the old horizontally-scrolling top
+ * tabs. Icons are inline stroke SVG (currentColor) so no icon library is added.
+ */
+
+const ICONS = {
+  home: "M3 11.5 12 3l9 8.5M5 10v10h14V10",
+  workouts: "M4 9v6M7 7v10M17 7v10M20 9v6M7 12h10",
+  progress: "M4 5v14h16M7 15l3-4 3 2 4-6",
+  exercises: "M8 6h12M8 12h12M8 18h12M4 6h.01M4 12h.01M4 18h.01",
+  more: "M6 12h.01M12 12h.01M18 12h.01",
+};
+
+const TABS = [
+  ["home", "Home"],
+  ["workouts", "Workouts"],
+  ["progress", "Progress"],
+  ["exercises", "Exercises"],
+  ["more", "More"],
+];
+
+function NavIcon({ name }) {
+  return (
+    <svg
+      width="22"
+      height="22"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={name === "more" ? 2.5 : 1.8}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d={ICONS[name]} />
+    </svg>
+  );
+}
+
+export default function BottomNav({ active, onSelect }) {
+  return (
+    <nav
+      aria-label="Primary"
+      className="fixed inset-x-0 bottom-0 z-20 border-t border-neutral-200 bg-white/95 backdrop-blur"
+    >
+      <div className="mx-auto flex max-w-3xl">
+        {TABS.map(([key, label]) => {
+          const isActive = active === key;
+          return (
+            <button
+              key={key}
+              type="button"
+              onClick={() => onSelect(key)}
+              aria-current={isActive ? "page" : undefined}
+              className={[
+                "flex flex-1 flex-col items-center gap-0.5 py-2 pb-[max(0.5rem,env(safe-area-inset-bottom))] text-[11px] transition",
+                isActive
+                  ? "text-blue-600"
+                  : "text-neutral-500 hover:text-neutral-800",
+              ].join(" ")}
+            >
+              <NavIcon name={key} />
+              {label}
+            </button>
+          );
+        })}
+      </div>
+    </nav>
+  );
+}

--- a/src/components/ui/BottomNav.test.jsx
+++ b/src/components/ui/BottomNav.test.jsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import BottomNav from "./BottomNav";
+
+describe("BottomNav", () => {
+  it("renders all five destinations", () => {
+    render(<BottomNav active="home" onSelect={() => {}} />);
+    for (const label of ["Home", "Workouts", "Progress", "Exercises", "More"]) {
+      expect(screen.getByRole("button", { name: label })).toBeInTheDocument();
+    }
+  });
+
+  it("marks the active tab with aria-current", () => {
+    render(<BottomNav active="progress" onSelect={() => {}} />);
+    expect(screen.getByRole("button", { name: "Progress" })).toHaveAttribute(
+      "aria-current",
+      "page",
+    );
+    expect(screen.getByRole("button", { name: "Home" })).not.toHaveAttribute(
+      "aria-current",
+    );
+  });
+
+  it("calls onSelect with the tab key when tapped", async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+    render(<BottomNav active="home" onSelect={onSelect} />);
+    await user.click(screen.getByRole("button", { name: "Exercises" }));
+    expect(onSelect).toHaveBeenCalledWith("exercises");
+  });
+});

--- a/src/components/ui/Button.jsx
+++ b/src/components/ui/Button.jsx
@@ -10,11 +10,12 @@ export function Button({
     "inline-flex items-center justify-center rounded-xl text-sm transition active:scale-[0.99] focus:outline-none";
   const sizes = { md: "px-3 py-1.5", sm: "px-2 py-1 text-xs", icon: "p-2" };
   const variants = {
-    primary: "border border-blue-600 bg-blue-600 text-white hover:bg-blue-700",
+    primary:
+      "border border-blue-600 bg-blue-600 text-white hover:bg-blue-700 dark:border-blue-500 dark:bg-blue-600 dark:hover:bg-blue-500",
     secondary:
-      "border border-neutral-300 bg-white hover:bg-neutral-50 text-neutral-900",
+      "border border-neutral-300 bg-white hover:bg-neutral-50 text-neutral-900 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100 dark:hover:bg-neutral-800",
     ghost:
-      "border-transparent bg-transparent hover:bg-neutral-100 text-neutral-800",
+      "border-transparent bg-transparent hover:bg-neutral-100 text-neutral-800 dark:text-neutral-200 dark:hover:bg-neutral-800",
   };
   return (
     <button

--- a/src/components/ui/Card.jsx
+++ b/src/components/ui/Card.jsx
@@ -4,7 +4,7 @@ export function Card({ children, className = "" }) {
   // Use a light gradient to better distinguish stacked cards
   return (
     <div
-      className={`bg-gradient-to-b from-white to-neutral-100 shadow border rounded-2xl ${className}`}
+      className={`bg-gradient-to-b from-white to-neutral-100 dark:from-neutral-900 dark:to-neutral-900 dark:border-neutral-800 shadow border rounded-2xl ${className}`}
     >
       {children}
     </div>

--- a/src/components/ui/ComboInput.jsx
+++ b/src/components/ui/ComboInput.jsx
@@ -28,7 +28,7 @@ export default function ComboInput({
     <>
       <input
         list={listId}
-        className="border dark:border-neutral-800 rounded-xl px-3 py-1.5 text-sm w-full"
+        className="border rounded-xl px-3 py-1.5 text-sm w-full bg-white dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100 dark:placeholder-neutral-500"
         value={value}
         placeholder={placeholder}
         onChange={(e) => onChange(e.target.value)}

--- a/src/components/ui/ComboInput.jsx
+++ b/src/components/ui/ComboInput.jsx
@@ -28,7 +28,7 @@ export default function ComboInput({
     <>
       <input
         list={listId}
-        className="border rounded-xl px-3 py-1.5 text-sm w-full"
+        className="border dark:border-neutral-800 rounded-xl px-3 py-1.5 text-sm w-full"
         value={value}
         placeholder={placeholder}
         onChange={(e) => onChange(e.target.value)}

--- a/src/components/ui/Input.jsx
+++ b/src/components/ui/Input.jsx
@@ -2,7 +2,7 @@ import React from "react";
 export function Input(props) {
   return (
     <input
-      className="border rounded-xl px-3 py-1.5 text-sm w-full bg-white dark:bg-neutral-900 dark:border-neutral-700 dark:text-neutral-100 dark:placeholder-neutral-500"
+      className="border rounded-xl px-3 py-1.5 text-sm w-full bg-white dark:bg-neutral-900 dark:border-neutral-700 dark:text-neutral-100 dark:placeholder-neutral-500 dark:[color-scheme:dark]"
       {...props}
     />
   );
@@ -10,7 +10,7 @@ export function Input(props) {
 export function Textarea(props) {
   return (
     <textarea
-      className="border rounded-xl px-3 py-1.5 text-sm w-full bg-white dark:bg-neutral-900 dark:border-neutral-700 dark:text-neutral-100 dark:placeholder-neutral-500"
+      className="border rounded-xl px-3 py-1.5 text-sm w-full bg-white dark:bg-neutral-900 dark:border-neutral-700 dark:text-neutral-100 dark:placeholder-neutral-500 dark:[color-scheme:dark]"
       {...props}
     />
   );

--- a/src/components/ui/Input.jsx
+++ b/src/components/ui/Input.jsx
@@ -2,7 +2,7 @@ import React from "react";
 export function Input(props) {
   return (
     <input
-      className="border rounded-xl px-3 py-1.5 text-sm w-full"
+      className="border rounded-xl px-3 py-1.5 text-sm w-full bg-white dark:bg-neutral-900 dark:border-neutral-700 dark:text-neutral-100 dark:placeholder-neutral-500"
       {...props}
     />
   );
@@ -10,7 +10,7 @@ export function Input(props) {
 export function Textarea(props) {
   return (
     <textarea
-      className="border rounded-xl px-3 py-1.5 text-sm w-full"
+      className="border rounded-xl px-3 py-1.5 text-sm w-full bg-white dark:bg-neutral-900 dark:border-neutral-700 dark:text-neutral-100 dark:placeholder-neutral-500"
       {...props}
     />
   );

--- a/src/components/ui/Segmented.jsx
+++ b/src/components/ui/Segmented.jsx
@@ -11,7 +11,9 @@ export default function Segmented({
   className = "",
 }) {
   return (
-    <div className={`inline-flex rounded-xl bg-neutral-100 p-1 ${className}`}>
+    <div
+      className={`inline-flex rounded-xl bg-neutral-100 p-1 dark:bg-neutral-800 ${className}`}
+    >
       {options.map(([val, label]) => {
         const active = val === value;
         return (
@@ -23,8 +25,8 @@ export default function Segmented({
             className={[
               "rounded-lg px-3 py-1.5 text-sm transition",
               active
-                ? "bg-white font-medium text-neutral-900 shadow-sm"
-                : "text-neutral-500 hover:text-neutral-800",
+                ? "bg-white font-medium text-neutral-900 shadow-sm dark:bg-neutral-700 dark:text-neutral-100"
+                : "text-neutral-500 hover:text-neutral-800 dark:text-neutral-400 dark:hover:text-neutral-200",
             ].join(" ")}
           >
             {label}

--- a/src/components/ui/Segmented.jsx
+++ b/src/components/ui/Segmented.jsx
@@ -1,0 +1,36 @@
+import React from "react";
+
+/**
+ * Pill segmented control for switching between a small set of views
+ * (e.g. List/Calendar, Bodyweight/Strength). Controlled via value/onChange.
+ */
+export default function Segmented({
+  options,
+  value,
+  onChange,
+  className = "",
+}) {
+  return (
+    <div className={`inline-flex rounded-xl bg-neutral-100 p-1 ${className}`}>
+      {options.map(([val, label]) => {
+        const active = val === value;
+        return (
+          <button
+            key={val}
+            type="button"
+            onClick={() => onChange(val)}
+            aria-pressed={active}
+            className={[
+              "rounded-lg px-3 py-1.5 text-sm transition",
+              active
+                ? "bg-white font-medium text-neutral-900 shadow-sm"
+                : "text-neutral-500 hover:text-neutral-800",
+            ].join(" ")}
+          >
+            {label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/context/AppContext.jsx
+++ b/src/context/AppContext.jsx
@@ -59,7 +59,7 @@ export function AppProvider({ children }) {
 
   // Start a live-logging session for an existing workout.
   const startSession = (workoutId) =>
-    setSession({ workoutId, startedAt: Date.now(), currentIdx: 0, done: {} });
+    setSession({ workoutId, startedAt: Date.now(), currentIdx: 0 });
   // Create a fresh, empty workout dated today and start logging it.
   const startEmptyWorkout = () => {
     const w = {

--- a/src/context/AppContext.jsx
+++ b/src/context/AppContext.jsx
@@ -1,6 +1,15 @@
 import React, { createContext, useContext, useState, useEffect } from "react";
 import seedExercises from "../data/exercises_seed.json";
-import { loadLS, saveLS, K_EX, K_WO, K_UNIT, K_TAB } from "../lib/storage";
+import {
+  loadLS,
+  saveLS,
+  K_EX,
+  K_WO,
+  K_UNIT,
+  K_TAB,
+  K_THEME,
+} from "../lib/storage";
+import { applyTheme } from "../lib/theme";
 
 /**
  * AppContext stores the top‑level app state: current tab,
@@ -14,12 +23,28 @@ export function AppProvider({ children }) {
   // Load initial values from localStorage (with sensible defaults)
   const [tab, setTab] = useState(() => loadLS(K_TAB, "workouts"));
   const [unit, setUnit] = useState(() => loadLS(K_UNIT, "kg"));
+  const [theme, setTheme] = useState(() => loadLS(K_THEME, "system"));
   const [exercises, setExercises] = useState(() => loadLS(K_EX, seedExercises));
   const [workouts, setWorkouts] = useState(() => loadLS(K_WO, []));
 
   // Persist tab and unit when they change
   useEffect(() => saveLS(K_TAB, tab), [tab]);
   useEffect(() => saveLS(K_UNIT, unit), [unit]);
+
+  // Persist the theme preference and apply it to <html>.
+  useEffect(() => {
+    saveLS(K_THEME, theme);
+    applyTheme(theme);
+  }, [theme]);
+
+  // While following the system, re-apply when the OS light/dark setting flips.
+  useEffect(() => {
+    if (theme !== "system" || typeof window.matchMedia !== "function") return;
+    const mql = window.matchMedia("(prefers-color-scheme: dark)");
+    const onChange = () => applyTheme("system");
+    mql.addEventListener?.("change", onChange);
+    return () => mql.removeEventListener?.("change", onChange);
+  }, [theme]);
 
   // Persist exercises and workouts when they change
   useEffect(() => saveLS(K_EX, exercises), [exercises]);
@@ -64,6 +89,8 @@ export function AppProvider({ children }) {
         setTab,
         unit,
         setUnit,
+        theme,
+        setTheme,
         exercises,
         setExercises,
         workouts,

--- a/src/context/AppContext.jsx
+++ b/src/context/AppContext.jsx
@@ -3,13 +3,16 @@ import seedExercises from "../data/exercises_seed.json";
 import {
   loadLS,
   saveLS,
+  uuid,
   K_EX,
   K_WO,
   K_UNIT,
   K_TAB,
   K_THEME,
+  K_SESSION,
 } from "../lib/storage";
 import { applyTheme } from "../lib/theme";
+import { ymdFromDate } from "../lib/date";
 
 /**
  * AppContext stores the top‑level app state: current tab,
@@ -26,6 +29,9 @@ export function AppProvider({ children }) {
   const [theme, setTheme] = useState(() => loadLS(K_THEME, "system"));
   const [exercises, setExercises] = useState(() => loadLS(K_EX, seedExercises));
   const [workouts, setWorkouts] = useState(() => loadLS(K_WO, []));
+  // In-progress live-logging session (or null). Persisted so a refresh mid-set
+  // resumes where you left off.
+  const [session, setSession] = useState(() => loadLS(K_SESSION, null));
 
   // Persist tab and unit when they change
   useEffect(() => saveLS(K_TAB, tab), [tab]);
@@ -49,6 +55,23 @@ export function AppProvider({ children }) {
   // Persist exercises and workouts when they change
   useEffect(() => saveLS(K_EX, exercises), [exercises]);
   useEffect(() => saveLS(K_WO, workouts), [workouts]);
+  useEffect(() => saveLS(K_SESSION, session), [session]);
+
+  // Start a live-logging session for an existing workout.
+  const startSession = (workoutId) =>
+    setSession({ workoutId, startedAt: Date.now(), currentIdx: 0, done: {} });
+  // Create a fresh, empty workout dated today and start logging it.
+  const startEmptyWorkout = () => {
+    const w = {
+      id: uuid(),
+      date: ymdFromDate(new Date()),
+      name: "",
+      exercises: [],
+    };
+    setWorkouts((prev) => [w, ...prev]);
+    startSession(w.id);
+  };
+  const endSession = () => setSession(null);
 
   // Update each exercise’s lastWorkout property whenever workouts change
   useEffect(() => {
@@ -95,6 +118,11 @@ export function AppProvider({ children }) {
         setExercises,
         workouts,
         setWorkouts,
+        session,
+        setSession,
+        startSession,
+        startEmptyWorkout,
+        endSession,
       }}
     >
       {children}

--- a/src/index.css
+++ b/src/index.css
@@ -10,6 +10,7 @@
   }
   body {
     @apply bg-neutral-50 text-neutral-900 antialiased;
+    @apply dark:bg-neutral-950 dark:text-neutral-100;
   }
 }
 @layer utilities {
@@ -19,7 +20,7 @@
 }
 @layer base {
   :is(button, input, textarea):focus {
-    @apply outline-none ring-2 ring-neutral-300;
+    @apply outline-none ring-2 ring-neutral-300 dark:ring-neutral-600;
   }
 }
 @media (max-width: 480px) {

--- a/src/lib/homeStats.js
+++ b/src/lib/homeStats.js
@@ -1,0 +1,76 @@
+// src/lib/homeStats.js
+// Pure helpers backing the Home dashboard. All weights are kg (see units.js);
+// these functions only sum/aggregate and never convert for display.
+
+import { toDate, startOfWeekMonday, endOfWeekSunday } from "./dateUtils";
+import { ymdFromDate } from "./date";
+
+/** Volume (kg) of one set: weight × reps, NaN-guarded. */
+export function setVolume(set) {
+  const w = Number(set?.weight ?? 0);
+  const r = Number(set?.reps ?? 0);
+  if (!Number.isFinite(w) || !Number.isFinite(r)) return 0;
+  return w * r;
+}
+
+/** Total volume (kg) of a workout across all exercises and sets. */
+export function workoutVolume(workout) {
+  let total = 0;
+  for (const ex of workout?.exercises || []) {
+    for (const s of ex.sets || []) total += setVolume(s);
+  }
+  return total;
+}
+
+/** Workouts whose date falls inside the Mon–Sun week containing refDate. */
+function workoutsInWeek(workouts, refDate) {
+  const from = startOfWeekMonday(refDate);
+  const to = endOfWeekSunday(refDate);
+  return (workouts || []).filter((w) => {
+    const d = toDate(w.date);
+    return d && d >= from && d <= to;
+  });
+}
+
+/** { count, volume } for the week containing refDate. */
+export function weekStats(workouts, refDate = new Date()) {
+  const inWeek = workoutsInWeek(workouts, refDate);
+  let volume = 0;
+  for (const w of inWeek) volume += workoutVolume(w);
+  return { count: inWeek.length, volume };
+}
+
+/** Seven volume totals (kg), Monday→Sunday, for the week containing refDate. */
+export function weekVolumeByDay(workouts, refDate = new Date()) {
+  const days = [0, 0, 0, 0, 0, 0, 0];
+  for (const w of workoutsInWeek(workouts, refDate)) {
+    const d = toDate(w.date);
+    const idx = (d.getDay() + 6) % 7; // Mon=0 … Sun=6
+    days[idx] += workoutVolume(w);
+  }
+  return days;
+}
+
+/**
+ * Consecutive calendar days, ending on refDate and counting backwards, on which
+ * at least one workout exists. Stops at the first day with no workout.
+ */
+export function currentStreak(workouts, refDate = new Date()) {
+  const dates = new Set((workouts || []).map((w) => w.date));
+  let streak = 0;
+  const cur = new Date(refDate);
+  cur.setHours(0, 0, 0, 0);
+  while (dates.has(ymdFromDate(cur))) {
+    streak += 1;
+    cur.setDate(cur.getDate() - 1);
+  }
+  return streak;
+}
+
+/** Most recent bodyweight log as { date, value }, or null when empty. */
+export function latestBodyweight(weightLogs) {
+  const keys = Object.keys(weightLogs || {});
+  if (keys.length === 0) return null;
+  const date = keys.sort().at(-1); // ISO date strings sort chronologically
+  return { date, value: weightLogs[date] };
+}

--- a/src/lib/homeStats.test.js
+++ b/src/lib/homeStats.test.js
@@ -1,0 +1,92 @@
+import {
+  setVolume,
+  workoutVolume,
+  weekStats,
+  weekVolumeByDay,
+  currentStreak,
+  latestBodyweight,
+} from "./homeStats";
+
+// Wednesday 2026-06-10 sits inside the Mon 2026-06-08 … Sun 2026-06-14 week.
+const REF = new Date("2026-06-10T12:00:00");
+
+const wo = (date, ...sets) => ({
+  id: date,
+  date,
+  exercises: [{ exerciseName: "Bench", sets }],
+});
+
+describe("setVolume / workoutVolume", () => {
+  it("multiplies weight by reps", () => {
+    expect(setVolume({ weight: 80, reps: 8 })).toBe(640);
+  });
+
+  it("treats missing/invalid fields as zero", () => {
+    expect(setVolume({ weight: "x", reps: 5 })).toBe(0);
+    expect(setVolume({})).toBe(0);
+    expect(setVolume(null)).toBe(0);
+  });
+
+  it("sums every set in a workout", () => {
+    expect(
+      workoutVolume(
+        wo("2026-06-10", { weight: 80, reps: 8 }, { weight: 80, reps: 6 }),
+      ),
+    ).toBe(80 * 8 + 80 * 6);
+  });
+});
+
+describe("weekStats", () => {
+  it("counts workouts and sums volume within the Mon–Sun week", () => {
+    const workouts = [
+      wo("2026-06-08", { weight: 100, reps: 5 }), // Mon, in week
+      wo("2026-06-14", { weight: 50, reps: 10 }), // Sun, in week
+      wo("2026-06-07", { weight: 999, reps: 9 }), // prev Sun, excluded
+      wo("2026-06-15", { weight: 999, reps: 9 }), // next Mon, excluded
+    ];
+    expect(weekStats(workouts, REF)).toEqual({ count: 2, volume: 500 + 500 });
+  });
+});
+
+describe("weekVolumeByDay", () => {
+  it("buckets volume Monday→Sunday", () => {
+    const days = weekVolumeByDay(
+      [
+        wo("2026-06-08", { weight: 100, reps: 1 }), // Mon → idx 0
+        wo("2026-06-14", { weight: 70, reps: 1 }), // Sun → idx 6
+      ],
+      REF,
+    );
+    expect(days).toEqual([100, 0, 0, 0, 0, 0, 70]);
+  });
+});
+
+describe("currentStreak", () => {
+  it("counts consecutive days ending on refDate", () => {
+    const workouts = [wo("2026-06-10"), wo("2026-06-09"), wo("2026-06-08")];
+    expect(currentStreak(workouts, REF)).toBe(3);
+  });
+
+  it("is zero when refDate itself has no workout", () => {
+    expect(currentStreak([wo("2026-06-09")], REF)).toBe(0);
+  });
+
+  it("stops at the first gap", () => {
+    // 06-10 and 06-09 present, 06-08 missing → streak of 2
+    expect(currentStreak([wo("2026-06-10"), wo("2026-06-09")], REF)).toBe(2);
+  });
+});
+
+describe("latestBodyweight", () => {
+  it("returns the most recent entry", () => {
+    expect(latestBodyweight({ "2026-06-01": 79, "2026-06-09": 78.6 })).toEqual({
+      date: "2026-06-09",
+      value: 78.6,
+    });
+  });
+
+  it("returns null when there are no logs", () => {
+    expect(latestBodyweight({})).toBeNull();
+    expect(latestBodyweight(null)).toBeNull();
+  });
+});

--- a/src/lib/liveSession.js
+++ b/src/lib/liveSession.js
@@ -1,28 +1,11 @@
 // src/lib/liveSession.js
-// Pure helpers for the live-logging session. The "done" state is a flat map
-// keyed by `${exerciseIndex}:${setIndex}` so it survives JSON round-trips and
-// is cheap to persist alongside the session pointer.
+// Pure helpers for the live-logging session. A set is considered "logged" once
+// it has reps entered (> 0) — there is no separate done flag, so completion
+// lives on the set itself and moves with its exercise when reordered.
 
-/** Stable key for a set's done-state within a session. */
-export const setKey = (exIdx, setIdx) => `${exIdx}:${setIdx}`;
-
-/** Is a given set marked done in this session's done-map? */
-export function isSetDone(done, exIdx, setIdx) {
-  return Boolean(done?.[setKey(exIdx, setIdx)]);
-}
-
-/** Toggle a set's done flag, returning a new done-map (false entries removed). */
-export function toggleDone(done, exIdx, setIdx) {
-  const key = setKey(exIdx, setIdx);
-  const next = { ...(done || {}) };
-  if (next[key]) delete next[key];
-  else next[key] = true;
-  return next;
-}
-
-/** Count of done sets across a whole session. */
-export function doneCount(done) {
-  return Object.values(done || {}).filter(Boolean).length;
+/** A set counts as logged once it has reps entered (> 0). */
+export function isLogged(set) {
+  return Number(set?.reps) > 0;
 }
 
 /** Total number of sets in a workout. */
@@ -32,28 +15,24 @@ export function totalSets(workout) {
   return n;
 }
 
+/** Count of logged sets across a whole workout. */
+export function completedSets(workout) {
+  let n = 0;
+  for (const ex of workout?.exercises || [])
+    for (const s of ex.sets || []) if (isLogged(s)) n += 1;
+  return n;
+}
+
 /**
  * New index of an exercise originally at `index` after moving the exercise at
- * `from` to `to` (matching arrayUtils.moveItem semantics).
+ * `from` to `to` (matching arrayUtils.moveItem semantics). Used to keep the
+ * on-screen exercise pointer (`currentIdx`) on the same exercise after a reorder.
  */
 export function remapIndexAfterMove(index, from, to) {
   if (index === from) return to;
   if (from < to) return index > from && index <= to ? index - 1 : index;
   if (from > to) return index >= to && index < from ? index + 1 : index;
   return index;
-}
-
-/**
- * Rebuild a done-map (keyed `"exerciseIdx:setIdx"`) so its exercise indices
- * follow a moveItem(from, to) reorder of the exercise list.
- */
-export function remapDoneAfterMove(done, from, to) {
-  const out = {};
-  for (const [k, v] of Object.entries(done || {})) {
-    const [ei, si] = k.split(":").map(Number);
-    out[setKey(remapIndexAfterMove(ei, from, to), si)] = v;
-  }
-  return out;
 }
 
 /**

--- a/src/lib/liveSession.js
+++ b/src/lib/liveSession.js
@@ -1,0 +1,48 @@
+// src/lib/liveSession.js
+// Pure helpers for the live-logging session. The "done" state is a flat map
+// keyed by `${exerciseIndex}:${setIndex}` so it survives JSON round-trips and
+// is cheap to persist alongside the session pointer.
+
+/** Stable key for a set's done-state within a session. */
+export const setKey = (exIdx, setIdx) => `${exIdx}:${setIdx}`;
+
+/** Is a given set marked done in this session's done-map? */
+export function isSetDone(done, exIdx, setIdx) {
+  return Boolean(done?.[setKey(exIdx, setIdx)]);
+}
+
+/** Toggle a set's done flag, returning a new done-map (false entries removed). */
+export function toggleDone(done, exIdx, setIdx) {
+  const key = setKey(exIdx, setIdx);
+  const next = { ...(done || {}) };
+  if (next[key]) delete next[key];
+  else next[key] = true;
+  return next;
+}
+
+/** Count of done sets across a whole session. */
+export function doneCount(done) {
+  return Object.values(done || {}).filter(Boolean).length;
+}
+
+/** Total number of sets in a workout. */
+export function totalSets(workout) {
+  let n = 0;
+  for (const ex of workout?.exercises || []) n += (ex.sets || []).length;
+  return n;
+}
+
+/**
+ * Format a duration in seconds as `M:SS` (or `H:MM:SS` past an hour). Negative
+ * inputs clamp to zero.
+ */
+export function formatClock(totalSeconds) {
+  const s = Math.max(0, Math.floor(totalSeconds));
+  const hours = Math.floor(s / 3600);
+  const mins = Math.floor((s % 3600) / 60);
+  const secs = s % 60;
+  const two = (n) => String(n).padStart(2, "0");
+  return hours > 0
+    ? `${hours}:${two(mins)}:${two(secs)}`
+    : `${mins}:${two(secs)}`;
+}

--- a/src/lib/liveSession.js
+++ b/src/lib/liveSession.js
@@ -33,6 +33,30 @@ export function totalSets(workout) {
 }
 
 /**
+ * New index of an exercise originally at `index` after moving the exercise at
+ * `from` to `to` (matching arrayUtils.moveItem semantics).
+ */
+export function remapIndexAfterMove(index, from, to) {
+  if (index === from) return to;
+  if (from < to) return index > from && index <= to ? index - 1 : index;
+  if (from > to) return index >= to && index < from ? index + 1 : index;
+  return index;
+}
+
+/**
+ * Rebuild a done-map (keyed `"exerciseIdx:setIdx"`) so its exercise indices
+ * follow a moveItem(from, to) reorder of the exercise list.
+ */
+export function remapDoneAfterMove(done, from, to) {
+  const out = {};
+  for (const [k, v] of Object.entries(done || {})) {
+    const [ei, si] = k.split(":").map(Number);
+    out[setKey(remapIndexAfterMove(ei, from, to), si)] = v;
+  }
+  return out;
+}
+
+/**
  * Format a duration in seconds as `M:SS` (or `H:MM:SS` past an hour). Negative
  * inputs clamp to zero.
  */

--- a/src/lib/liveSession.test.js
+++ b/src/lib/liveSession.test.js
@@ -1,0 +1,60 @@
+import {
+  setKey,
+  isSetDone,
+  toggleDone,
+  doneCount,
+  totalSets,
+  formatClock,
+} from "./liveSession";
+
+describe("done-map helpers", () => {
+  it("keys by exercise:set", () => {
+    expect(setKey(1, 2)).toBe("1:2");
+  });
+
+  it("toggles a set on and off immutably", () => {
+    const a = toggleDone({}, 0, 0);
+    expect(isSetDone(a, 0, 0)).toBe(true);
+    const b = toggleDone(a, 0, 0);
+    expect(isSetDone(b, 0, 0)).toBe(false);
+    // original map untouched
+    expect(isSetDone(a, 0, 0)).toBe(true);
+  });
+
+  it("counts done sets", () => {
+    let done = {};
+    done = toggleDone(done, 0, 0);
+    done = toggleDone(done, 0, 1);
+    expect(doneCount(done)).toBe(2);
+  });
+});
+
+describe("totalSets", () => {
+  it("sums sets across exercises", () => {
+    const workout = {
+      exercises: [{ sets: [1, 2, 3] }, { sets: [1] }, { sets: [] }],
+    };
+    expect(totalSets(workout)).toBe(4);
+  });
+
+  it("is zero for an empty/absent workout", () => {
+    expect(totalSets({ exercises: [] })).toBe(0);
+    expect(totalSets(null)).toBe(0);
+  });
+});
+
+describe("formatClock", () => {
+  it("formats minutes and seconds", () => {
+    expect(formatClock(0)).toBe("0:00");
+    expect(formatClock(9)).toBe("0:09");
+    expect(formatClock(75)).toBe("1:15");
+  });
+
+  it("adds an hours field past 3600s", () => {
+    expect(formatClock(3661)).toBe("1:01:01");
+  });
+
+  it("clamps negatives to zero", () => {
+    expect(formatClock(-5)).toBe("0:00");
+  });
+});

--- a/src/lib/liveSession.test.js
+++ b/src/lib/liveSession.test.js
@@ -5,6 +5,8 @@ import {
   doneCount,
   totalSets,
   formatClock,
+  remapIndexAfterMove,
+  remapDoneAfterMove,
 } from "./liveSession";
 
 describe("done-map helpers", () => {
@@ -40,6 +42,47 @@ describe("totalSets", () => {
   it("is zero for an empty/absent workout", () => {
     expect(totalSets({ exercises: [] })).toBe(0);
     expect(totalSets(null)).toBe(0);
+  });
+});
+
+describe("remapIndexAfterMove", () => {
+  it("maps the moved exercise to its destination", () => {
+    expect(remapIndexAfterMove(0, 0, 2)).toBe(2);
+    expect(remapIndexAfterMove(3, 3, 1)).toBe(1);
+  });
+
+  it("shifts indices passed over by a downward move", () => {
+    // move 0 -> 2: old 1 and 2 slide up to 0 and 1
+    expect(remapIndexAfterMove(1, 0, 2)).toBe(0);
+    expect(remapIndexAfterMove(2, 0, 2)).toBe(1);
+    expect(remapIndexAfterMove(3, 0, 2)).toBe(3); // untouched
+  });
+
+  it("shifts indices passed over by an upward move", () => {
+    // move 3 -> 1: old 1 and 2 slide down to 2 and 3
+    expect(remapIndexAfterMove(1, 3, 1)).toBe(2);
+    expect(remapIndexAfterMove(2, 3, 1)).toBe(3);
+    expect(remapIndexAfterMove(0, 3, 1)).toBe(0); // untouched
+  });
+
+  it("handles an adjacent swap", () => {
+    expect(remapIndexAfterMove(1, 1, 2)).toBe(2);
+    expect(remapIndexAfterMove(2, 1, 2)).toBe(1);
+  });
+});
+
+describe("remapDoneAfterMove", () => {
+  it("keeps done flags attached to their exercise after a swap", () => {
+    // exercise 0 has set 0 done, exercise 1 has set 1 done; swap 0<->1
+    const done = { "0:0": true, "1:1": true };
+    expect(remapDoneAfterMove(done, 0, 1)).toEqual({
+      "1:0": true,
+      "0:1": true,
+    });
+  });
+
+  it("leaves set indices untouched", () => {
+    expect(remapDoneAfterMove({ "2:3": true }, 0, 1)).toEqual({ "2:3": true });
   });
 });
 

--- a/src/lib/liveSession.test.js
+++ b/src/lib/liveSession.test.js
@@ -1,33 +1,27 @@
 import {
-  setKey,
-  isSetDone,
-  toggleDone,
-  doneCount,
+  isLogged,
   totalSets,
-  formatClock,
+  completedSets,
   remapIndexAfterMove,
-  remapDoneAfterMove,
+  formatClock,
 } from "./liveSession";
 
-describe("done-map helpers", () => {
-  it("keys by exercise:set", () => {
-    expect(setKey(1, 2)).toBe("1:2");
+describe("isLogged / completedSets", () => {
+  it("treats a set with reps > 0 as logged", () => {
+    expect(isLogged({ reps: 8 })).toBe(true);
+    expect(isLogged({ reps: 0 })).toBe(false);
+    expect(isLogged({})).toBe(false);
+    expect(isLogged(null)).toBe(false);
   });
 
-  it("toggles a set on and off immutably", () => {
-    const a = toggleDone({}, 0, 0);
-    expect(isSetDone(a, 0, 0)).toBe(true);
-    const b = toggleDone(a, 0, 0);
-    expect(isSetDone(b, 0, 0)).toBe(false);
-    // original map untouched
-    expect(isSetDone(a, 0, 0)).toBe(true);
-  });
-
-  it("counts done sets", () => {
-    let done = {};
-    done = toggleDone(done, 0, 0);
-    done = toggleDone(done, 0, 1);
-    expect(doneCount(done)).toBe(2);
+  it("counts logged sets across exercises", () => {
+    const workout = {
+      exercises: [
+        { sets: [{ reps: 8 }, { reps: 0 }] },
+        { sets: [{ reps: 5 }] },
+      ],
+    };
+    expect(completedSets(workout)).toBe(2);
   });
 });
 
@@ -68,21 +62,6 @@ describe("remapIndexAfterMove", () => {
   it("handles an adjacent swap", () => {
     expect(remapIndexAfterMove(1, 1, 2)).toBe(2);
     expect(remapIndexAfterMove(2, 1, 2)).toBe(1);
-  });
-});
-
-describe("remapDoneAfterMove", () => {
-  it("keeps done flags attached to their exercise after a swap", () => {
-    // exercise 0 has set 0 done, exercise 1 has set 1 done; swap 0<->1
-    const done = { "0:0": true, "1:1": true };
-    expect(remapDoneAfterMove(done, 0, 1)).toEqual({
-      "1:0": true,
-      "0:1": true,
-    });
-  });
-
-  it("leaves set indices untouched", () => {
-    expect(remapDoneAfterMove({ "2:3": true }, 0, 1)).toEqual({ "2:3": true });
   });
 });
 

--- a/src/lib/storage.js
+++ b/src/lib/storage.js
@@ -11,6 +11,8 @@ export const K_WO = "mgym.workouts.v1";
 export const K_UNIT = "mgym.unit";
 /** localStorage key for the last active tab. */
 export const K_TAB = "mgym.tab";
+/** localStorage key for the theme preference ("system" | "light" | "dark"). */
+export const K_THEME = "mgym.theme";
 /** localStorage key for body-weight logs ({ "YYYY-MM-DD": number }). Predates the "mgym" prefix. */
 export const K_WEIGHT_LOGS = "weightLogs";
 

--- a/src/lib/storage.js
+++ b/src/lib/storage.js
@@ -13,6 +13,8 @@ export const K_UNIT = "mgym.unit";
 export const K_TAB = "mgym.tab";
 /** localStorage key for the theme preference ("system" | "light" | "dark"). */
 export const K_THEME = "mgym.theme";
+/** localStorage key for the in-progress live workout session (or null). */
+export const K_SESSION = "mgym.session.v1";
 /** localStorage key for body-weight logs ({ "YYYY-MM-DD": number }). Predates the "mgym" prefix. */
 export const K_WEIGHT_LOGS = "weightLogs";
 

--- a/src/lib/theme.js
+++ b/src/lib/theme.js
@@ -1,0 +1,29 @@
+// src/lib/theme.js
+// Theme preference resolution. The app stores one of three preferences —
+// "system" | "light" | "dark" — and applies a concrete light/dark mode by
+// toggling the `dark` class on <html> (Tailwind darkMode: "class").
+
+/** Valid theme preferences, in toggle order. */
+export const THEME_OPTIONS = ["system", "light", "dark"];
+
+/** Does the OS currently prefer dark? Safe when matchMedia is unavailable. */
+export function systemPrefersDark() {
+  return (
+    typeof window !== "undefined" &&
+    typeof window.matchMedia === "function" &&
+    window.matchMedia("(prefers-color-scheme: dark)").matches
+  );
+}
+
+/** Resolve a preference to a concrete boolean "is dark". */
+export function resolveDark(pref) {
+  if (pref === "dark") return true;
+  if (pref === "light") return false;
+  return systemPrefersDark(); // "system" (and any unknown value)
+}
+
+/** Apply a preference by toggling the `dark` class on the document root. */
+export function applyTheme(pref) {
+  if (typeof document === "undefined") return;
+  document.documentElement.classList.toggle("dark", resolveDark(pref));
+}

--- a/src/lib/theme.test.js
+++ b/src/lib/theme.test.js
@@ -1,0 +1,47 @@
+import { resolveDark, applyTheme, THEME_OPTIONS } from "./theme";
+
+/** Stub window.matchMedia to report a fixed system preference. */
+function stubSystem(prefersDark) {
+  window.matchMedia = (query) => ({
+    matches: prefersDark && query.includes("dark"),
+    media: query,
+    addEventListener() {},
+    removeEventListener() {},
+  });
+}
+
+afterEach(() => {
+  document.documentElement.classList.remove("dark");
+});
+
+describe("resolveDark", () => {
+  it("honors explicit light/dark regardless of system", () => {
+    stubSystem(true);
+    expect(resolveDark("light")).toBe(false);
+    stubSystem(false);
+    expect(resolveDark("dark")).toBe(true);
+  });
+
+  it("follows the system preference for 'system'", () => {
+    stubSystem(true);
+    expect(resolveDark("system")).toBe(true);
+    stubSystem(false);
+    expect(resolveDark("system")).toBe(false);
+  });
+});
+
+describe("applyTheme", () => {
+  it("toggles the dark class on <html>", () => {
+    stubSystem(false);
+    applyTheme("dark");
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+    applyTheme("light");
+    expect(document.documentElement.classList.contains("dark")).toBe(false);
+  });
+});
+
+describe("THEME_OPTIONS", () => {
+  it("exposes the three preferences", () => {
+    expect(THEME_OPTIONS).toEqual(["system", "light", "dark"]);
+  });
+});

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 export default {
+  darkMode: "class",
   content: ["./index.html", "./src/**/*.{js,jsx,ts,tsx}"],
   theme: {
     extend: {


### PR DESCRIPTION
## What & why

A mobile-first UI/UX revamp of the gym tracker plus a new live-logging mode. The app's weakest point was navigation: six top tabs that scrolled off-screen on a phone, with no landing view. This restructures the app around a bottom tab bar and adds the features that make it usable mid-workout.

Built incrementally as 9 focused commits — reviewable commit-by-commit.

## Highlights

**Navigation revamp (Calm Light)**
- Six scrolling top tabs → a fixed **5-tab bottom nav**: Home · Workouts · Progress · Exercises · More.
- New **Home dashboard** (greeting, streak, today's plan + Start, week stats, recent).
- Consolidation: Progress merges the old Weight + Summary (Bodyweight/Strength toggle); Calendar folds into Workouts (List/Calendar toggle); Notepad + data export/import + prefs live under More.
- Legacy persisted `tab` values (`calendar`/`weight`/`summary`/`notepad`) are remapped so returning users never hit a blank screen.

**Dark theme**
- Class-based Tailwind (`darkMode: "class"`) with a Light/Dark/Auto control in More; Auto follows the OS and re-applies live on system change. Persisted to `mgym.theme`.

**Exercise Manager polish**
- Header + live count, muscle-group filter chips, collapsible "+ New" form; closed the dark-mode gaps on native inputs.

**Live-logging mode** (the big new feature)
- Full-screen `LiveSession` with an elapsed clock and a logged-sets counter.
- Entry points: "Start" on Home's today card and on each history item; "Start empty workout" on Home and Workouts.
- A set counts as **logged once it has reps** (no separate Done step); new sets/exercises start with reps cleared (weight prefills).
- **Reorder** exercises by dragging the chips (pointer-based, works on touch + mouse) or ↑/↓ buttons.
- **Replace** the current exercise in place, or **remove** it (with a confirm) — for when a machine is taken mid-plan.
- Per-exercise **RPE + feedback** (reuses `RpeFeedback`).
- Manual **rest timer** with 3 / 2 / 1.5-min presets and ±15s / skip.
- Session persists to `mgym.session.v1` so a refresh mid-workout resumes.

**Also**
- kg/lb toggle temporarily **hidden** (commented out, easy to restore) pending the known bodyweight-conversion bug, so the app shows kg consistently.
- ARCHITECTURE.md and docs/DATA-MODEL.md updated for the new IA, theme + session keys, and the reps-based completion model.

## Constraints held

No new dependencies, no router, localStorage model intact (additive keys only: `mgym.theme`, `mgym.session.v1`). Bundle ~69.5 KB gzip JS / ~5 KB gzip CSS.

## Testing

`npm run check` green — lint, format, **186 tests** (new co-located tests for `homeStats`, `theme`, `liveSession`, `BottomNav`, `Home`, `ExerciseManager`, `LiveSession`, and the tab wrappers), and production build. Verified interactively in the browser (mobile viewport, light + dark): all five tabs, theme toggle, exercise filtering, and the full live-logging flow incl. drag-reorder, replace, remove + confirm, RPE, and rest presets.

## Reviewer notes

- Committed-and-tested but worth a manual smoke on a real phone for the pointer-drag reorder.
- The Exercises screen reuses the existing `ExerciseManager`; its header now matches the mockups.
- The bodyweight kg/lb bug is pre-existing (ARCHITECTURE open question #1) and only surfaced more (hence hiding the toggle) — not fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
