### PR TITLE
Fix Strength tab exercise picker; add searchable Combobox

### DIFF
--- a/src/components/StrengthAnalysis.jsx
+++ b/src/components/StrengthAnalysis.jsx
@@ -6,7 +6,7 @@
 import React, { useMemo, useState } from "react";
 import { useApp } from "../context/AppContext";
 import Segmented from "./ui/Segmented";
-import ComboInput from "./ui/ComboInput";
+import Combobox from "./ui/Combobox";
 import Delta from "./Delta";
 import MultiLineChart from "./MultiLineChart";
 import { toDisplayWeight } from "../lib/units";
@@ -84,10 +84,15 @@ export default function StrengthAnalysis() {
 
   const [range, setRange] = useState("6M");
   const [metric, setMetric] = useState("e1rm");
-  const [exercise, setExercise] = useState("");
+  // Seed the drill-down with a sensible default once, but keep the input fully
+  // editable afterwards — binding the field to a fallback would repopulate it
+  // the instant the user clears it, blocking both retyping and the dropdown.
+  const [exercise, setExercise] = useState(
+    () => mostRecentExercise(wos) || loggedExerciseNames(wos)[0] || "",
+  );
 
   const names = useMemo(() => loggedExerciseNames(wos), [wos]);
-  const selected = exercise || mostRecentExercise(wos) || names[0] || "";
+  const selected = exercise;
 
   // Current vs previous equal-length window for trend deltas. Destructure the
   // memoized result so each derived useMemo depends on a stable value.
@@ -250,7 +255,7 @@ export default function StrengthAnalysis() {
           <label className="text-xs text-neutral-500 dark:text-neutral-400">
             Exercise
           </label>
-          <ComboInput
+          <Combobox
             value={selected}
             onChange={setExercise}
             options={names}

--- a/src/components/StrengthAnalysis.test.jsx
+++ b/src/components/StrengthAnalysis.test.jsx
@@ -67,4 +67,18 @@ describe("StrengthAnalysis", () => {
     // Still renders the overview after re-windowing.
     expect(screen.getByText("Recent PRs")).toBeInTheDocument();
   });
+
+  it("keeps the exercise field clearable instead of refilling a default", async () => {
+    seed();
+    const user = userEvent.setup();
+    render(<StrengthAnalysis />);
+    const input = screen.getByPlaceholderText("Pick an exercise");
+    // Seeded with the most-recent lift, but the user can empty it...
+    expect(input).toHaveValue("Squat");
+    await user.clear(input);
+    expect(input).toHaveValue("");
+    // ...and type a fresh value without it snapping back.
+    await user.type(input, "Bench");
+    expect(input).toHaveValue("Bench");
+  });
 });

--- a/src/components/ui/Combobox.jsx
+++ b/src/components/ui/Combobox.jsx
@@ -1,0 +1,193 @@
+import React, { useEffect, useId, useMemo, useRef, useState } from "react";
+
+/**
+ * Searchable select: click the caret (or focus) to drop down the full list,
+ * type to filter it, then pick with the mouse or keyboard. Unlike the native
+ * <datalist> in ComboInput, the popup is rendered by us, so "show everything"
+ * and "filter as I type" both work consistently across browsers.
+ *
+ * Controlled via value/onChange (the committed string). Free text is allowed —
+ * typing a value that isn't in `options` is fine, it just won't match a row.
+ */
+export default function Combobox({
+  value,
+  onChange,
+  options = [],
+  placeholder = "",
+  id,
+}) {
+  const autoId = useId();
+  const listId = id || `cb-${autoId}`;
+  const [open, setOpen] = useState(false);
+  // When true the popup ignores the current value and shows every option (set
+  // on focus / caret click). The first keystroke flips it off so typing filters.
+  const [showAll, setShowAll] = useState(false);
+  const [active, setActive] = useState(-1);
+  const rootRef = useRef(null);
+  const inputRef = useRef(null);
+  const listRef = useRef(null);
+
+  const uniq = useMemo(() => {
+    const set = new Set();
+    const out = [];
+    for (const o of options) {
+      const v = String(o || "").trim();
+      if (!v) continue;
+      const k = v.toLowerCase();
+      if (!set.has(k)) {
+        set.add(k);
+        out.push(v);
+      }
+      if (out.length >= 500) break;
+    }
+    return out;
+  }, [options]);
+
+  const q = String(value || "")
+    .trim()
+    .toLowerCase();
+  const filtered = useMemo(
+    () =>
+      showAll || !q ? uniq : uniq.filter((o) => o.toLowerCase().includes(q)),
+    [uniq, q, showAll],
+  );
+
+  // Close when focus/click leaves the component.
+  useEffect(() => {
+    if (!open) return;
+    const onDocPointer = (e) => {
+      if (rootRef.current && !rootRef.current.contains(e.target))
+        setOpen(false);
+    };
+    document.addEventListener("mousedown", onDocPointer);
+    return () => document.removeEventListener("mousedown", onDocPointer);
+  }, [open]);
+
+  // Keep the highlighted row scrolled into view.
+  useEffect(() => {
+    if (!open || active < 0 || !listRef.current) return;
+    const el = listRef.current.children[active];
+    if (el && el.scrollIntoView) el.scrollIntoView({ block: "nearest" });
+  }, [active, open]);
+
+  const openList = (all) => {
+    setShowAll(all);
+    setActive(-1);
+    setOpen(true);
+  };
+
+  const select = (opt) => {
+    onChange(opt);
+    setOpen(false);
+    setShowAll(false);
+    setActive(-1);
+  };
+
+  const onKeyDown = (e) => {
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      if (!open) return openList(showAll);
+      setActive((i) => Math.min(i + 1, filtered.length - 1));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      if (!open) return openList(showAll);
+      setActive((i) => Math.max(i - 1, 0));
+    } else if (e.key === "Enter") {
+      if (open && active >= 0 && active < filtered.length) {
+        e.preventDefault();
+        select(filtered[active]);
+      }
+    } else if (e.key === "Escape") {
+      if (open) {
+        e.preventDefault();
+        setOpen(false);
+      }
+    }
+  };
+
+  return (
+    <div ref={rootRef} className="relative">
+      <input
+        ref={inputRef}
+        role="combobox"
+        aria-expanded={open}
+        aria-controls={listId}
+        aria-autocomplete="list"
+        className="w-full rounded-xl border bg-white px-3 py-1.5 pr-9 text-sm dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100 dark:placeholder-neutral-500"
+        value={value}
+        placeholder={placeholder}
+        onChange={(e) => {
+          onChange(e.target.value);
+          setShowAll(false);
+          setActive(-1);
+          setOpen(true);
+        }}
+        onFocus={() => openList(true)}
+        onKeyDown={onKeyDown}
+      />
+      <button
+        type="button"
+        tabIndex={-1}
+        aria-label={open ? "Hide options" : "Show all options"}
+        className="absolute inset-y-0 right-0 flex items-center px-2 text-neutral-400 hover:text-neutral-600 dark:hover:text-neutral-200"
+        onMouseDown={(e) => e.preventDefault()}
+        onClick={() => {
+          if (open) {
+            setOpen(false);
+          } else {
+            openList(true);
+            inputRef.current?.focus();
+          }
+        }}
+      >
+        <svg
+          width="16"
+          height="16"
+          viewBox="0 0 20 20"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          className={`transition-transform ${open ? "rotate-180" : ""}`}
+          aria-hidden="true"
+        >
+          <path d="M6 8l4 4 4-4" strokeLinecap="round" strokeLinejoin="round" />
+        </svg>
+      </button>
+
+      {open && filtered.length > 0 && (
+        <ul
+          id={listId}
+          ref={listRef}
+          role="listbox"
+          className="absolute z-20 mt-1 max-h-60 w-full overflow-auto rounded-xl border bg-white py-1 text-sm shadow-lg dark:border-neutral-700 dark:bg-neutral-900"
+        >
+          {filtered.map((opt, i) => {
+            const isActive = i === active;
+            const isSelected = opt === value;
+            return (
+              <li
+                key={opt}
+                role="option"
+                aria-selected={isSelected}
+                onMouseEnter={() => setActive(i)}
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  select(opt);
+                }}
+                className={[
+                  "cursor-pointer px-3 py-1.5",
+                  isActive
+                    ? "bg-neutral-100 dark:bg-neutral-800"
+                    : "text-neutral-700 dark:text-neutral-200",
+                  isSelected ? "font-medium" : "",
+                ].join(" ")}
+              >
+                {opt}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/components/ui/Combobox.test.jsx
+++ b/src/components/ui/Combobox.test.jsx
@@ -1,0 +1,74 @@
+import React, { useState } from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import Combobox from "./Combobox";
+
+const OPTIONS = ["Bench Press Barbell", "Deadlift", "Squat Barbell"];
+
+// Controlled wrapper so onChange actually updates the displayed value.
+function Harness({ initial = "", options = OPTIONS }) {
+  const [value, setValue] = useState(initial);
+  return (
+    <Combobox
+      value={value}
+      onChange={setValue}
+      options={options}
+      placeholder="Pick an exercise"
+    />
+  );
+}
+
+const optionsListed = () =>
+  screen.queryAllByRole("option").map((o) => o.textContent);
+
+describe("Combobox", () => {
+  it("shows every option when opened, even with a value already selected", async () => {
+    const user = userEvent.setup();
+    render(<Harness initial="Squat Barbell" />);
+    await user.click(screen.getByRole("button", { name: /show all options/i }));
+    expect(optionsListed()).toEqual(OPTIONS);
+  });
+
+  it("filters the list as you type", async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    await user.type(screen.getByRole("combobox"), "bench");
+    expect(optionsListed()).toEqual(["Bench Press Barbell"]);
+  });
+
+  it("commits the clicked option and closes the list", async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    await user.click(screen.getByRole("button", { name: /show all options/i }));
+    await user.click(screen.getByRole("option", { name: "Deadlift" }));
+    expect(screen.getByRole("combobox")).toHaveValue("Deadlift");
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+  });
+
+  it("selects with keyboard arrows and Enter", async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    const input = screen.getByRole("combobox");
+    await user.click(input);
+    await user.keyboard("{ArrowDown}{ArrowDown}{Enter}");
+    expect(input).toHaveValue("Deadlift");
+  });
+
+  it("allows free text that matches nothing", async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    const input = screen.getByRole("combobox");
+    await user.type(input, "Cable Fly");
+    expect(input).toHaveValue("Cable Fly");
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+  });
+
+  it("closes on Escape", async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    await user.click(screen.getByRole("button", { name: /show all options/i }));
+    expect(screen.getByRole("listbox")).toBeInTheDocument();
+    await user.keyboard("{Escape}");
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Problem

The **Progress → Strength** exercise picker was unusable:

- You couldn't **clear the field** to type a fresh exercise — deleting the text instantly repopulated it.
- You couldn't **open the full dropdown** — the native `<datalist>` only reliably shows everything when the field is empty, which was impossible given the above.

Root cause: the input was bound to a value with a fallback baked in (`exercise || mostRecentExercise || names[0]`), so the moment `exercise` became `""`, the fallback fired and refilled it.

## Changes

1. **Fix the picker state** (`src/components/StrengthAnalysis.jsx`) — seed the default exercise once at mount and bind the field to the real, editable state. Fully clearable and retypeable.

2. **New `Combobox` UI primitive** (`src/components/ui/Combobox.jsx`) replacing the native `<datalist>`, which behaves inconsistently across browsers:
   - Caret button / focus drops down **every** option, even with one selected.
   - Typing **filters** the list (case-insensitive substring).
   - Mouse **and** keyboard selection (↑/↓, Enter, Esc, click-outside).
   - Free text still allowed; selected row bolded; light/dark themed.

The shared `ComboInput` (muscle/type/equipment free-text fields) is intentionally left as-is.

## Tests

- Regression test: the exercise field stays clearable and retypeable.
- 6 new `Combobox` tests: show-all, filter, click-select, keyboard nav, free text, Escape.
- `npm run check` green: lint + format + **202 tests** + build.

## Verification

Browser-tested in light and dark mode — open-shows-all, type-filters, click/keyboard-selects-and-closes all confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
