### PR TITLE
Replace SVG charts with interactive Recharts charts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.1.0",
       "dependencies": {
         "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react-dom": "^18.2.0",
+        "recharts": "^3.8.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
@@ -1268,6 +1269,42 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.12.0.tgz",
+      "integrity": "sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.8",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.8.tgz",
+      "integrity": "sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
@@ -1664,6 +1701,18 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
+    },
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
@@ -1818,6 +1867,69 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -1837,6 +1949,12 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
     "node_modules/@vitejs/plugin-react": {
@@ -2582,6 +2700,15 @@
         "node": ">= 6"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2675,6 +2802,127 @@
         "node": ">=4"
       }
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/data-urls": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
@@ -2766,6 +3014,12 @@
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
     "node_modules/deep-eql": {
@@ -3085,6 +3339,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/es-toolkit": {
+      "version": "1.47.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.47.1.tgz",
+      "integrity": "sha512-5RAqEwf4P4E17p+W75KLOWw/nOvKZzSQpxM32IpI2KZLaVonjTrZ0Ai5ghMaVI9eKC2p8eoQgcBdkEDgzFk6+Q==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
+    },
     "node_modules/esbuild": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
@@ -3403,6 +3667,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/expect-type": {
       "version": "1.3.0",
@@ -3911,6 +4181,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -3961,6 +4241,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-array-buffer": {
@@ -5446,8 +5735,30 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-redux": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
+      "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",
@@ -5482,6 +5793,36 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/recharts": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
+      "integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -5494,6 +5835,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -5549,6 +5905,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.12",
@@ -6204,6 +6566,12 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -6523,12 +6891,43 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
+      }
     },
     "node_modules/vite": {
       "version": "5.4.21",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   },
   "dependencies": {
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "recharts": "^3.8.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",

--- a/src/components/MultiLineChart.jsx
+++ b/src/components/MultiLineChart.jsx
@@ -1,26 +1,82 @@
-import React from "react";
+import React, { useState } from "react";
+import {
+  ResponsiveContainer,
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  Brush,
+  LabelList,
+} from "recharts";
 
 /**
- * A compact multi-series SVG line chart. Generalizes the single-line pattern
- * from WeightChart so it can plot one series (per-exercise progression) or
- * several (volume by muscle) on a shared axis.
+ * An interactive multi-series line chart built on Recharts. Generalizes the
+ * single-line pattern from WeightChart so it can plot one series (per-exercise
+ * progression, body weight) or several (volume by muscle) on a shared axis.
+ *
+ * Interactions:
+ *   - hover / tap a point for a tooltip with every series' value at that x
+ *   - drag the brush handles under the chart to zoom into a sub-range
+ *   - click a legend entry to hide / show that series (multi-series only)
  *
  * Props:
  *   series  – [{ name, color, points: number[] }]. All series share the same
  *             x indices; `points` align with `labels` by index. Non-finite
- *             values are skipped. `color` defaults to currentColor.
+ *             values are plotted as gaps but the line connects across them.
+ *             `color` defaults to currentColor (inherits the parent text color).
  *   labels  – x-axis labels (strings), one per index.
- *   showValues – when true and there is a single series, draws the rounded
- *             y-value above sampled points (like WeightChart).
+ *   showValues – when true and there is a single (short) series, draws the
+ *             rounded y-value above each point (like the old WeightChart).
+ *   height  – chart height in px (default 240).
  */
+
+// Tailwind-styled tooltip so values read clearly in both light and dark mode,
+// instead of Recharts' default inline-styled white box.
+function ChartTooltip({ active, payload, label }) {
+  if (!active || !payload || payload.length === 0) return null;
+  const rows = payload.filter((p) => p.value != null);
+  if (rows.length === 0) return null;
+  return (
+    <div className="rounded-md border bg-white px-2.5 py-1.5 text-xs shadow-sm dark:border-neutral-700 dark:bg-neutral-800">
+      <div className="mb-0.5 font-medium text-neutral-500 dark:text-neutral-400">
+        {label}
+      </div>
+      {rows.map((p) => (
+        <div key={p.dataKey} className="flex items-center gap-1.5 tabular-nums">
+          <span
+            className="inline-block h-2 w-2 rounded-sm"
+            style={{ background: p.color }}
+          />
+          {rows.length > 1 && (
+            <span className="text-neutral-600 dark:text-neutral-300">
+              {p.name}
+            </span>
+          )}
+          <span className="font-semibold">{Math.round(p.value * 10) / 10}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
 export default function MultiLineChart({
   series = [],
   labels = [],
-  height = 200,
-  width = 720,
-  padding = 32,
+  height = 240,
   showValues = false,
 }) {
+  // Track which series are toggled off via the legend, keyed by line dataKey.
+  const [hidden, setHidden] = useState(() => new Set());
+  const toggle = (key) =>
+    setHidden((prev) => {
+      const next = new Set(prev);
+      next.has(key) ? next.delete(key) : next.add(key);
+      return next;
+    });
+
   const ys = series.flatMap((s) => s.points).filter((v) => Number.isFinite(v));
   if (labels.length < 2 || ys.length === 0) {
     return (
@@ -30,94 +86,110 @@ export default function MultiLineChart({
     );
   }
 
-  const minY = Math.min(...ys);
-  const maxY = Math.max(...ys);
-  const lastIdx = labels.length - 1;
-  const scaleX = (i) => padding + (i / (lastIdx || 1)) * (width - padding * 2);
-  const scaleY = (y) =>
-    height -
-    padding -
-    ((y - minY) / (maxY - minY || 1)) * (height - padding * 2);
+  // Recharts wants row-major data: one object per x index, each series under a
+  // stable key (v0, v1…) so names with odd characters can't collide with axes.
+  const data = labels.map((label, i) => {
+    const row = { label };
+    series.forEach((s, si) => {
+      const y = s.points[i];
+      row[`v${si}`] = Number.isFinite(y) ? y : null;
+    });
+    return row;
+  });
 
-  // Show at most ~8 x-labels, always including the last point.
-  const labelStep = Math.max(1, Math.ceil(labels.length / 8));
-  const showLabel = (i) => i === lastIdx || i % labelStep === 0;
-  // Markers get noisy past ~40 points; hide them on long ranges.
-  const showMarkers = labels.length <= 40;
-  const single = series.length === 1;
+  const multi = series.length > 1;
+  // Markers and always-on value labels get noisy on long ranges; the tooltip
+  // covers detail past those thresholds.
+  const showDots = data.length <= 40;
+  const withValueLabels = showValues && !multi && data.length <= 12;
+  // Only offer the zoom brush once there's enough data to be worth zooming.
+  const showBrush = data.length > 8;
+
+  const axisTick = { fontSize: 11, fill: "currentColor", opacity: 0.6 };
 
   return (
-    <svg
-      viewBox={`0 0 ${width} ${height}`}
-      preserveAspectRatio="none"
-      className="w-full"
-      style={{ height }}
-    >
-      {series.map((s, si) => {
-        const pts = s.points
-          .map((y, i) =>
-            Number.isFinite(y) ? `${scaleX(i)},${scaleY(y)}` : null,
-          )
-          .filter(Boolean)
-          .join(" ");
-        return (
-          <polyline
-            key={s.name || si}
-            fill="none"
-            stroke={s.color || "currentColor"}
-            strokeWidth="2"
-            vectorEffect="non-scaling-stroke"
-            points={pts}
+    <ResponsiveContainer width="100%" height={height}>
+      <LineChart
+        data={data}
+        margin={{ top: 12, right: 12, bottom: 4, left: -8 }}
+      >
+        <CartesianGrid
+          strokeDasharray="3 3"
+          stroke="currentColor"
+          opacity={0.12}
+          vertical={false}
+        />
+        <XAxis
+          dataKey="label"
+          tick={axisTick}
+          tickLine={false}
+          axisLine={{ stroke: "currentColor", opacity: 0.2 }}
+          minTickGap={24}
+          interval="preserveStartEnd"
+        />
+        <YAxis
+          tick={axisTick}
+          tickLine={false}
+          axisLine={false}
+          width={36}
+          domain={["auto", "auto"]}
+        />
+        <Tooltip
+          content={<ChartTooltip />}
+          cursor={{ stroke: "currentColor", opacity: 0.2 }}
+        />
+        {multi && (
+          <Legend
+            onClick={(o) => toggle(o.dataKey)}
+            wrapperStyle={{ fontSize: 12, cursor: "pointer" }}
+            formatter={(value, entry) => (
+              <span
+                className="text-neutral-600 dark:text-neutral-300"
+                style={{ opacity: hidden.has(entry.dataKey) ? 0.4 : 1 }}
+              >
+                {value}
+              </span>
+            )}
           />
-        );
-      })}
-
-      {series.map((s, si) =>
-        s.points.map((y, i) => {
-          if (!Number.isFinite(y)) return null;
-          const cx = scaleX(i);
-          const cy = scaleY(y);
+        )}
+        {series.map((s, si) => {
+          const key = `v${si}`;
           return (
-            <g key={`${si}-${i}`}>
-              {showMarkers && (
-                <circle
-                  cx={cx}
-                  cy={cy}
-                  r="3"
-                  fill={s.color || "currentColor"}
+            <Line
+              key={key}
+              type="monotone"
+              dataKey={key}
+              name={s.name}
+              stroke={s.color || "currentColor"}
+              strokeWidth={2}
+              connectNulls
+              hide={hidden.has(key)}
+              dot={showDots ? { r: 2.5 } : false}
+              activeDot={{ r: 4 }}
+              isAnimationActive={false}
+            >
+              {withValueLabels && (
+                <LabelList
+                  dataKey={key}
+                  position="top"
+                  fontSize={10}
+                  fill="currentColor"
+                  formatter={(v) => (v == null ? "" : Math.round(v))}
                 />
               )}
-              {showValues && single && showLabel(i) && (
-                <text
-                  x={cx}
-                  y={cy - 8}
-                  fontSize="10"
-                  textAnchor="middle"
-                  fill="currentColor"
-                >
-                  {Math.round(y)}
-                </text>
-              )}
-            </g>
+            </Line>
           );
-        }),
-      )}
-
-      {labels.map((lab, i) =>
-        showLabel(i) ? (
-          <text
-            key={`l-${i}`}
-            x={scaleX(i)}
-            y={height - padding + 14}
-            fontSize="9"
-            textAnchor="middle"
-            fill="currentColor"
-            opacity="0.6"
-          >
-            {lab}
-          </text>
-        ) : null,
-      )}
-    </svg>
+        })}
+        {showBrush && (
+          <Brush
+            dataKey="label"
+            height={22}
+            travellerWidth={8}
+            stroke="currentColor"
+            tickFormatter={() => ""}
+          />
+        )}
+      </LineChart>
+    </ResponsiveContainer>
   );
 }

--- a/src/components/MultiLineChart.test.jsx
+++ b/src/components/MultiLineChart.test.jsx
@@ -2,6 +2,12 @@ import React from "react";
 import { render, screen } from "@testing-library/react";
 import MultiLineChart from "./MultiLineChart";
 
+vi.mock("recharts", async (importOriginal) => {
+  const { withFixedResponsiveContainer } =
+    await import("../test/rechartsTestUtils");
+  return withFixedResponsiveContainer(await importOriginal());
+});
+
 describe("MultiLineChart", () => {
   it("shows an empty message without enough data", () => {
     render(
@@ -10,7 +16,7 @@ describe("MultiLineChart", () => {
     expect(screen.getByText(/not enough data/i)).toBeInTheDocument();
   });
 
-  it("draws one polyline per series", () => {
+  it("draws one line per series", () => {
     const { container } = render(
       <MultiLineChart
         series={[
@@ -20,7 +26,21 @@ describe("MultiLineChart", () => {
         labels={["w1", "w2", "w3"]}
       />,
     );
-    expect(container.querySelectorAll("polyline")).toHaveLength(2);
+    expect(container.querySelectorAll(".recharts-line")).toHaveLength(2);
+  });
+
+  it("renders an interactive legend for multiple series", () => {
+    render(
+      <MultiLineChart
+        series={[
+          { name: "Quads", color: "#111", points: [1, 2, 3] },
+          { name: "Back", color: "#222", points: [3, 2, 1] },
+        ]}
+        labels={["w1", "w2", "w3"]}
+      />,
+    );
+    expect(screen.getByText("Quads")).toBeInTheDocument();
+    expect(screen.getByText("Back")).toBeInTheDocument();
   });
 
   it("renders rounded value labels for a single series when showValues is set", () => {
@@ -34,6 +54,7 @@ describe("MultiLineChart", () => {
     const texts = [...container.querySelectorAll("text")].map(
       (t) => t.textContent,
     );
-    expect(texts).toContain("21"); // 20.6 rounded, last point always labelled
+    expect(texts).toContain("21"); // 20.6 rounded
+    expect(texts).toContain("10"); // 10.4 rounded
   });
 });

--- a/src/components/StrengthAnalysis.jsx
+++ b/src/components/StrengthAnalysis.jsx
@@ -234,19 +234,6 @@ export default function StrengthAnalysis() {
         <div className="rounded-lg border dark:border-neutral-800 p-3 text-neutral-700 dark:text-neutral-300">
           <MultiLineChart series={muscleSeries} labels={muscleLabels} />
         </div>
-        {muscleSeries.length > 0 && (
-          <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-neutral-500 dark:text-neutral-400">
-            {muscleSeries.map((m) => (
-              <span key={m.name} className="inline-flex items-center gap-1">
-                <span
-                  className="inline-block h-2.5 w-2.5 rounded-sm"
-                  style={{ background: m.color }}
-                />
-                {m.name}
-              </span>
-            ))}
-          </div>
-        )}
       </div>
 
       {/* Per-exercise drill-down */}

--- a/src/components/StrengthAnalysis.test.jsx
+++ b/src/components/StrengthAnalysis.test.jsx
@@ -8,6 +8,12 @@ vi.mock("../context/AppContext", () => ({
   useApp: () => mockApp,
 }));
 
+vi.mock("recharts", async (importOriginal) => {
+  const { withFixedResponsiveContainer } =
+    await import("../test/rechartsTestUtils");
+  return withFixedResponsiveContainer(await importOriginal());
+});
+
 const daysAgo = (n) => {
   const d = new Date();
   d.setDate(d.getDate() - n);
@@ -48,7 +54,9 @@ describe("StrengthAnalysis", () => {
     // The PR feed lists the squat that beat the prior best.
     expect(screen.getAllByText("Squat").length).toBeGreaterThan(0);
     // A chart line is drawn (muscle trend and/or per-exercise curve).
-    expect(container.querySelectorAll("polyline").length).toBeGreaterThan(0);
+    expect(container.querySelectorAll(".recharts-line").length).toBeGreaterThan(
+      0,
+    );
   });
 
   it("switches the per-exercise chart metric without crashing", async () => {
@@ -56,7 +64,9 @@ describe("StrengthAnalysis", () => {
     const user = userEvent.setup();
     const { container } = render(<StrengthAnalysis />);
     await user.click(screen.getByRole("button", { name: "Volume" }));
-    expect(container.querySelectorAll("polyline").length).toBeGreaterThan(0);
+    expect(container.querySelectorAll(".recharts-line").length).toBeGreaterThan(
+      0,
+    );
   });
 
   it("switches the time range", async () => {

--- a/src/components/WeightChart.jsx
+++ b/src/components/WeightChart.jsx
@@ -1,92 +1,7 @@
 import React, { useMemo } from "react";
 import { loadLS, K_WEIGHT_LOGS } from "../lib/storage";
 import { buildWeightSeries } from "../lib/weightSeries";
-
-/**
- * A simple SVG line chart. Fits the width of its container (no horizontal
- * scrolling) and samples labels so long ranges stay readable. Markers are
- * only drawn when the series is short enough not to look noisy.
- */
-function SimpleLineChart({ points, height = 200, width = 720, padding = 32 }) {
-  if (!points || points.length < 2) {
-    return (
-      <div className="text-sm text-neutral-500 dark:text-neutral-400">
-        Not enough data to plot.
-      </div>
-    );
-  }
-  const ys = points.map((p) => p.y);
-  const minY = Math.min(...ys);
-  const maxY = Math.max(...ys);
-  const lastIdx = points.length - 1;
-  const scaleX = (x) => padding + (x / (lastIdx || 1)) * (width - padding * 2);
-  const scaleY = (y) =>
-    height -
-    padding -
-    ((y - minY) / (maxY - minY || 1)) * (height - padding * 2);
-  const linePoints = points
-    .map((p) => `${scaleX(p.x)},${scaleY(p.y)}`)
-    .join(" ");
-
-  // Show at most ~8 labels along the axis, always including the last point.
-  const labelStep = Math.max(1, Math.ceil(points.length / 8));
-  const showLabel = (i) => i === lastIdx || i % labelStep === 0;
-  // Markers get noisy past ~40 points; hide them on long ranges.
-  const showMarkers = points.length <= 40;
-
-  return (
-    <svg
-      viewBox={`0 0 ${width} ${height}`}
-      preserveAspectRatio="none"
-      className="w-full"
-      style={{ height }}
-    >
-      {/* line */}
-      <polyline
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="2"
-        vectorEffect="non-scaling-stroke"
-        points={linePoints}
-      />
-      {points.map((p, i) => {
-        const cx = scaleX(p.x);
-        const cy = scaleY(p.y);
-        const labelled = showLabel(i);
-        return (
-          <g key={i}>
-            {showMarkers && (
-              <circle cx={cx} cy={cy} r="3" fill="currentColor" />
-            )}
-            {labelled && (
-              <>
-                <text
-                  x={cx}
-                  y={cy - 8}
-                  fontSize="10"
-                  textAnchor="middle"
-                  fill="currentColor"
-                >
-                  {p.y}
-                </text>
-                <text
-                  x={cx}
-                  y={height - padding + 14}
-                  fontSize="9"
-                  textAnchor="middle"
-                  fill="currentColor"
-                  opacity="0.6"
-                >
-                  {p.label}
-                </text>
-              </>
-            )}
-          </g>
-        );
-      })}
-    </svg>
-  );
-}
+import MultiLineChart from "./MultiLineChart";
 
 /**
  * Line chart for body-weight logs over a selected period.
@@ -95,6 +10,10 @@ function SimpleLineChart({ points, height = 200, width = 720, padding = 32 }) {
  * most recent prior weight forward (see buildWeightSeries), so adjacent points
  * always represent consecutive days. Weekly view averages the filled days per
  * ISO week.
+ *
+ * Rendering (interactive tooltip, brush-to-zoom, value labels) is delegated to
+ * MultiLineChart — this component only shapes the weight series into a single
+ * line.
  *
  * Props:
  *   logs (optional) – map of ISO date strings to weights (falls back to LS).
@@ -109,15 +28,14 @@ export default function WeightChart({ logs, view = "daily", from, to }) {
     [rawLogs, from, to, view],
   );
 
-  const points = useMemo(
-    () =>
-      series.map((row, idx) => ({
-        x: idx,
-        y: row.weight,
-        label: row.date.slice(5), // MM-DD
-      })),
+  const labels = useMemo(
+    () => series.map((row) => row.date.slice(5)),
+    [series],
+  ); // MM-DD
+  const lineSeries = useMemo(
+    () => [{ name: "Weight", points: series.map((row) => row.weight) }],
     [series],
   );
 
-  return <SimpleLineChart points={points} />;
+  return <MultiLineChart series={lineSeries} labels={labels} showValues />;
 }

--- a/src/components/WeightChart.test.jsx
+++ b/src/components/WeightChart.test.jsx
@@ -1,0 +1,35 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import WeightChart from "./WeightChart";
+
+vi.mock("recharts", async (importOriginal) => {
+  const { withFixedResponsiveContainer } =
+    await import("../test/rechartsTestUtils");
+  return withFixedResponsiveContainer(await importOriginal());
+});
+
+const day = (d) => new Date(2026, 0, d); // Jan 2026
+
+describe("WeightChart", () => {
+  it("shows the empty state when a single day can't form a line", () => {
+    render(
+      <WeightChart logs={{ "2026-01-01": 80 }} from={day(1)} to={day(1)} />,
+    );
+    expect(screen.getByText(/not enough data/i)).toBeInTheDocument();
+  });
+
+  it("plots the body-weight series across the range", () => {
+    const logs = { "2026-01-01": 80, "2026-01-03": 81 };
+    const { container } = render(
+      <WeightChart logs={logs} from={day(1)} to={day(3)} view="daily" />,
+    );
+    // One line is drawn for the weight series.
+    expect(container.querySelectorAll(".recharts-line")).toHaveLength(1);
+    // Days without a log carry the prior weight forward (Jan 2 == 80).
+    const texts = [...container.querySelectorAll("text")].map(
+      (t) => t.textContent,
+    );
+    expect(texts).toContain("80");
+    expect(texts).toContain("81");
+  });
+});

--- a/src/test/rechartsTestUtils.js
+++ b/src/test/rechartsTestUtils.js
@@ -1,0 +1,28 @@
+import { cloneElement } from "react";
+
+/**
+ * Recharts' ResponsiveContainer measures its parent with ResizeObserver; under
+ * jsdom that measurement lands a render too late and the chart's lines never
+ * mount. Tests mock the container to a fixed size so the child chart renders
+ * synchronously.
+ *
+ * Usage (must be at the top of a test file — vi.mock is hoisted):
+ *
+ *   vi.mock("recharts", async (importOriginal) => {
+ *     const { withFixedResponsiveContainer } = await import(
+ *       "../test/rechartsTestUtils"
+ *     );
+ *     return withFixedResponsiveContainer(await importOriginal());
+ *   });
+ */
+export function withFixedResponsiveContainer(
+  actual,
+  width = 800,
+  height = 300,
+) {
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children, height: h = height }) =>
+      cloneElement(children, { width, height: h }),
+  };
+}

--- a/src/test/setup.js
+++ b/src/test/setup.js
@@ -1,6 +1,17 @@
 import "@testing-library/jest-dom/vitest";
 import { afterEach } from "vitest";
 
+// jsdom doesn't implement ResizeObserver, which Recharts' ResponsiveContainer
+// references. Chart tests mock ResponsiveContainer to a fixed size, but provide
+// a no-op here so any other consumer doesn't throw a ReferenceError.
+if (typeof global.ResizeObserver === "undefined") {
+  global.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+}
+
 // jsdom's localStorage persists across tests within a file — wipe it so
 // AppContext / storage tests can't leak mgym.* keys into each other.
 afterEach(() => {


### PR DESCRIPTION
## What & why

The body-weight and strength charts were hand-rolled SVG: labels were hard to
read and there was no interactivity — no tooltips, no zoom, no way to focus a
single series. This rebuilds both charts on **Recharts** so they're readable
and interactive.

## Changes

- **`MultiLineChart.jsx`** is now the single Recharts implementation, adding:
  - **Tooltip** — hover/tap shows a Tailwind-styled card (dark-mode aware) with every visible series' rounded value
  - **Brush zoom** — drag the bar under the chart to zoom into a sub-range (touch-friendly)
  - **Interactive legend** — tap a series to hide/show it; the Y-axis auto-rescales (multi-series only)
  - Readable axes + gridlines; dots hidden past 40 points; `connectNulls` across gap-filled days
- **`WeightChart.jsx`** now just shapes the weight series and delegates rendering to `MultiLineChart` (DRY — it already "generalized the single-line pattern").
- **`StrengthAnalysis.jsx`** drops its static external muscle legend in favor of the new interactive one.
- **Tests**: updated `.recharts-line` assertions, added `WeightChart.test.jsx`, and a shared `rechartsTestUtils.js` that mocks `ResponsiveContainer` to a fixed size — Recharts v3 won't mount lines under jsdom's zero-size layout otherwise. `setup.js` gets a no-op `ResizeObserver` shim.

## Verification

- `npm run check` green (lint, format, **205 tests**, build); pre-push hook passed.
- Manually verified in the dev server at mobile width: tooltip rendered correct rounded values, the legend toggle hid a series and rescaled the axis, the brush rendered on all three charts, and the console was clean. Single-series (body weight, per-exercise) and multi-series (volume by muscle) all render.

## Reviewer notes

- **Bundle size**: Recharts is the heaviest of the options considered — the gzipped JS bundle is now ~180 KB (613 KB raw), which trips Vite's 500 KB chunk warning. Acceptable for now; a follow-up could `React.lazy` the Progress tab to keep it off the initial load.
- New dependency: `recharts` (`^3.8.1`) — the only runtime dep added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
