### PR TITLE
Add past-logs history to live logging mode

### DIFF
--- a/src/components/LiveSession.jsx
+++ b/src/components/LiveSession.jsx
@@ -14,6 +14,7 @@ import { moveItem } from "../lib/arrayUtils";
 import WeightRepInputs from "./WeightRepInputs";
 import AddExerciseInput from "./AddExerciseInput";
 import RpeFeedback from "./RpeFeedback";
+import ExerciseHistoryModal from "./ExerciseHistoryModal";
 import { Trash2 } from "./ui/Icons";
 import { useConfirm } from "./ConfirmDialog";
 
@@ -64,6 +65,8 @@ export default function LiveSession() {
   const suppressClickRef = useRef(false);
   // Inline "replace exercise" picker for the current exercise.
   const [swapping, setSwapping] = useState(false);
+  // Exercise whose past-workout history is shown in the modal (null = closed).
+  const [historyExercise, setHistoryExercise] = useState(null);
   const confirm = useConfirm();
 
   // If the workout vanished (e.g. deleted elsewhere), close the session.
@@ -299,9 +302,14 @@ export default function LiveSession() {
                 Exercise {currentIdx + 1} of {exs.length}
               </div>
               <div className="mb-3 flex items-center justify-between gap-2">
-                <div className="min-w-0 flex-1 truncate text-lg font-semibold text-neutral-900 dark:text-neutral-100">
+                <button
+                  type="button"
+                  onClick={() => setHistoryExercise(current.exerciseName)}
+                  title="View past logs"
+                  className="min-w-0 flex-1 truncate text-left text-lg font-semibold text-neutral-900 underline decoration-dotted underline-offset-4 transition hover:text-blue-600 dark:text-neutral-100 dark:hover:text-blue-400"
+                >
                   {current.exerciseName}
-                </div>
+                </button>
                 <div className="flex shrink-0 items-center gap-1">
                   {exs.length > 1 && (
                     <>
@@ -529,6 +537,14 @@ export default function LiveSession() {
           )}
         </div>
       </div>
+
+      {/* Past-logs modal — excludes the in-progress workout itself */}
+      <ExerciseHistoryModal
+        exerciseName={historyExercise}
+        workouts={workouts.filter((w) => w.id !== workout.id)}
+        unit={unit}
+        onClose={() => setHistoryExercise(null)}
+      />
     </div>
   );
 }

--- a/src/components/LiveSession.test.jsx
+++ b/src/components/LiveSession.test.jsx
@@ -140,6 +140,42 @@ describe("LiveSession", () => {
     expect(screen.getByText("Squat")).toBeInTheDocument();
   });
 
+  it("opens past logs for the current exercise, excluding the live workout", async () => {
+    const user = userEvent.setup();
+    saveLS(K_WO, [
+      {
+        id: "past",
+        date: "2026-06-06",
+        name: "Last week",
+        exercises: [
+          { exerciseName: "Bench", sets: [{ set: 1, weight: 75, reps: 10 }] },
+        ],
+      },
+      {
+        id: "live",
+        date: "2026-06-13",
+        name: "Push Day",
+        exercises: [
+          { exerciseName: "Bench", sets: [{ set: 1, weight: 80, reps: 8 }] },
+        ],
+      },
+    ]);
+    saveLS(K_SESSION, {
+      workoutId: "live",
+      startedAt: Date.now(),
+      currentIdx: 0,
+    });
+    renderLive();
+
+    await user.click(screen.getByRole("button", { name: "Bench" }));
+
+    // Modal shows the prior workout's set, not the in-progress one.
+    expect(screen.getByText(/Past workouts/i)).toBeInTheDocument();
+    expect(screen.getByText("Last week")).toBeInTheDocument();
+    expect(screen.getByText(/Set 1: 75 kg × 10/)).toBeInTheDocument();
+    expect(screen.queryByText(/Set 1: 80 kg × 8/)).not.toBeInTheDocument();
+  });
+
   it("closes the session when finished", async () => {
     const user = userEvent.setup();
     seedAndRender();


### PR DESCRIPTION
## What

Adds the ability to view an exercise's past logs while in **live-logging mode**, matching the behavior plan mode already has.

In live mode there was no way to see history for the exercise you're currently logging. Now the current exercise title is a tappable button (dotted underline, "View past logs" tooltip) that opens the existing `ExerciseHistoryModal` — the same modal plan mode uses when you tap an exercise name.

## Why

Users couldn't reference what they lifted last time without leaving the session. This brings parity with plan mode so history is one tap away mid-workout.

## Notes for reviewers

- Reuses `ExerciseHistoryModal` rather than building a new view, so behavior/styling stays consistent across modes.
- The **in-progress workout is filtered out** of the history list (`workouts.filter(w => w.id !== workout.id)`), so you only see genuinely past sessions — not the one you're currently logging.
- The modal lists all past workouts containing the exercise (grouped by date), identical to plan mode. If a more compact "last session only" inline view is preferred for the live flow, that's an easy follow-up.

## Testing

- New RTL test in `LiveSession.test.jsx` verifies the modal opens, shows the prior workout's sets, and excludes the live workout.
- Verified live in the browser preview (modal renders over the session, no console errors).
- `npm run check` passes (206 tests, lint/format, build) — also enforced by the pre-push hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
