### PR TITLE
Keep rest timer running across tab/app switches

### DIFF
--- a/src/components/LiveSession.jsx
+++ b/src/components/LiveSession.jsx
@@ -9,6 +9,7 @@ import {
   totalSets,
   formatClock,
   remapIndexAfterMove,
+  restRemaining,
 } from "../lib/liveSession";
 import { moveItem } from "../lib/arrayUtils";
 import WeightRepInputs from "./WeightRepInputs";
@@ -39,25 +40,33 @@ export default function LiveSession() {
 
   const workout = workouts.find((w) => w.id === session?.workoutId) || null;
 
-  // Tick the elapsed clock once a second.
+  // A single 1-second tick drives both the elapsed clock and the rest timer.
+  // Both derive their displayed value from timestamps (not a decremented
+  // counter), so a backgrounded mobile tab that freezes the interval still
+  // shows the right time the instant it returns to the foreground.
   const [nowTs, setNowTs] = useState(() => Date.now());
   useEffect(() => {
-    const id = setInterval(() => setNowTs(Date.now()), 1000);
-    return () => clearInterval(id);
+    const tick = () => setNowTs(Date.now());
+    const id = setInterval(tick, 1000);
+    // Resync immediately on return — while hidden the interval may not have
+    // fired, so the clock would otherwise show a stale value for up to a second.
+    const onVisible = () => {
+      if (document.visibilityState === "visible") tick();
+    };
+    document.addEventListener("visibilitychange", onVisible);
+    return () => {
+      clearInterval(id);
+      document.removeEventListener("visibilitychange", onVisible);
+    };
   }, []);
 
-  // Manual rest timer: null when idle, else seconds remaining. The countdown
-  // ticks inside the timeout callback and clears itself at zero, so the effect
-  // body never sets state synchronously.
-  const [restLeft, setRestLeft] = useState(null);
-  useEffect(() => {
-    if (restLeft == null || restLeft <= 0) return undefined;
-    const id = setTimeout(
-      () => setRestLeft((s) => (s != null && s <= 1 ? null : s - 1)),
-      1000,
-    );
-    return () => clearTimeout(id);
-  }, [restLeft]);
+  // Manual rest timer: null when idle, else the wall-clock instant it ends at.
+  // Remaining seconds are derived from `nowTs`, so the countdown stays accurate
+  // across tab/app switches instead of pausing when the timer interval freezes.
+  const [restEndsAt, setRestEndsAt] = useState(null);
+  // null while idle; once it reaches 0 the bar reverts to the presets below, so
+  // `restLeft > 0` is treated as "timer running" and no clear-at-zero is needed.
+  const restLeft = restRemaining(restEndsAt, nowTs);
 
   // Drag-to-reorder the exercise chips. Pointer-based so it works on touch and
   // mouse alike (HTML5 drag-and-drop doesn't fire on touch).
@@ -466,8 +475,8 @@ export default function LiveSession() {
       {/* Bottom bar: rest timer + prev/next */}
       <div className="border-t bg-white px-4 py-3 dark:border-neutral-800 dark:bg-neutral-900">
         <div className="mx-auto max-w-3xl space-y-3">
-          {/* Rest timer (manual) */}
-          {restLeft == null ? (
+          {/* Rest timer (manual) — reverts to presets at zero */}
+          {!restLeft ? (
             <div className="flex items-center gap-2">
               <span className="text-xs text-neutral-500 dark:text-neutral-400">
                 Rest
@@ -476,7 +485,7 @@ export default function LiveSession() {
                 <button
                   key={secs}
                   type="button"
-                  onClick={() => setRestLeft(secs)}
+                  onClick={() => setRestEndsAt(Date.now() + secs * 1000)}
                   className="flex-1 rounded-xl bg-neutral-100 py-2 text-sm font-medium text-neutral-700 transition hover:bg-neutral-200 dark:bg-neutral-800 dark:text-neutral-200 dark:hover:bg-neutral-700"
                 >
                   {label}
@@ -491,21 +500,23 @@ export default function LiveSession() {
               <span className="flex items-center gap-2">
                 <button
                   type="button"
-                  onClick={() => setRestLeft((s) => Math.max(0, s - 15))}
+                  onClick={() =>
+                    setRestEndsAt((t) => Math.max(Date.now(), t - 15000))
+                  }
                   className="rounded-lg px-2 py-1 text-xs text-blue-700 hover:bg-blue-100 dark:text-blue-300 dark:hover:bg-neutral-700"
                 >
                   −15s
                 </button>
                 <button
                   type="button"
-                  onClick={() => setRestLeft((s) => s + 15)}
+                  onClick={() => setRestEndsAt((t) => t + 15000)}
                   className="rounded-lg px-2 py-1 text-xs text-blue-700 hover:bg-blue-100 dark:text-blue-300 dark:hover:bg-neutral-700"
                 >
                   +15s
                 </button>
                 <button
                   type="button"
-                  onClick={() => setRestLeft(null)}
+                  onClick={() => setRestEndsAt(null)}
                   className="rounded-lg px-2 py-1 text-xs font-medium text-blue-700 hover:bg-blue-100 dark:text-blue-300 dark:hover:bg-neutral-700"
                 >
                   Skip

--- a/src/lib/liveSession.js
+++ b/src/lib/liveSession.js
@@ -36,6 +36,19 @@ export function remapIndexAfterMove(index, from, to) {
 }
 
 /**
+ * Whole seconds left on a timer that ends at the wall-clock instant `endsAt`
+ * (ms epoch), given the current time `now` (ms epoch). Deriving the countdown
+ * from a target timestamp — rather than decrementing a per-tick counter — keeps
+ * it accurate when a mobile browser freezes timers on a backgrounded tab: the
+ * value self-corrects the moment the clock next advances. Returns 0 once the
+ * timer has elapsed; `null` endsAt (idle) returns null.
+ */
+export function restRemaining(endsAt, now) {
+  if (endsAt == null) return null;
+  return Math.max(0, Math.floor((endsAt - now) / 1000));
+}
+
+/**
  * Format a duration in seconds as `M:SS` (or `H:MM:SS` past an hour). Negative
  * inputs clamp to zero.
  */

--- a/src/lib/liveSession.test.js
+++ b/src/lib/liveSession.test.js
@@ -4,6 +4,7 @@ import {
   completedSets,
   remapIndexAfterMove,
   formatClock,
+  restRemaining,
 } from "./liveSession";
 
 describe("isLogged / completedSets", () => {
@@ -62,6 +63,29 @@ describe("remapIndexAfterMove", () => {
   it("handles an adjacent swap", () => {
     expect(remapIndexAfterMove(1, 1, 2)).toBe(2);
     expect(remapIndexAfterMove(2, 1, 2)).toBe(1);
+  });
+});
+
+describe("restRemaining", () => {
+  it("is null when idle", () => {
+    expect(restRemaining(null, 1000)).toBe(null);
+  });
+
+  it("derives whole seconds left from the target instant", () => {
+    expect(restRemaining(120_000, 0)).toBe(120);
+    expect(restRemaining(120_000, 30_500)).toBe(89); // floors partial seconds
+  });
+
+  it("reflects real elapsed time after a frozen-timer gap, not tick count", () => {
+    // Tab hidden ~91s with no ticks: the next `now` reading alone yields the
+    // correct remaining time — no per-second decrements needed in between.
+    const endsAt = 120_000; // started at now=0 with a 2-min rest
+    expect(restRemaining(endsAt, 91_000)).toBe(29);
+  });
+
+  it("clamps to zero once elapsed", () => {
+    expect(restRemaining(120_000, 120_000)).toBe(0);
+    expect(restRemaining(120_000, 200_000)).toBe(0);
   });
 });
 


### PR DESCRIPTION
## What

The live-session **rest timer** now stays accurate when you background the tab or switch apps on mobile, instead of pausing and resuming where it left off.

## Why

Mobile browsers throttle/freeze `setInterval` and `setTimeout` on backgrounded tabs. The rest timer decremented a per-tick counter (`setRestLeft((s) => s - 1)`), so when ticks stopped firing the countdown effectively stalled — which is the "timer stops when I switch apps" behavior reported.

The elapsed clock at the top was already timestamp-based and self-corrected on return; only the rest timer had the bug.

## How

- Store the rest timer as a **target timestamp** (`restEndsAt`) rather than seconds-remaining.
- Derive remaining seconds from `Date.now()` on each render via a new pure helper `restRemaining(endsAt, now)` in `src/lib/liveSession.js`. The displayed value is correct the instant the component re-renders, no matter how many ticks actually fired while hidden.
- Add a `visibilitychange` listener so returning to the tab resyncs immediately instead of waiting up to a second for the next interval.
- `+15s` / `-15s` / `Skip` / preset buttons adjust the timestamp; the bar reverts to the presets at zero (no clear-at-zero effect, so it stays lint-clean re: no setState-in-effect).

## Tests

- Extracted the countdown math into `restRemaining` specifically so it is unit-testable per the repo's lib-helper convention.
- New cases in `src/lib/liveSession.test.js`, including a "frozen-timer gap" scenario asserting the value reflects real elapsed time rather than tick count.
- `npm run check` passes (lint + format + tests + build).

## Scope note

This fixes app/tab **switching** (the throttling case). If iOS Safari fully *discards* a long-backgrounded tab, the page reloads and the rest timer resets — the workout session itself survives since it is persisted. Persisting the rest timer across a full reload was left out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
