### PR TITLE
Add Strength Symmetry radar to Progress tab

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -9,10 +9,19 @@ workflow see [CONTRIBUTING.md](CONTRIBUTING.md).
 ## System overview
 
 Gym Tracker is a **single-page application that runs entirely in the browser**.
-There is no server, no API, and no account system. Everything is kept in the
+There is no server of our own and no account system. Everything is kept in the
 browser's `localStorage`, so the app is local-first and works offline after the
 initial load. Data never leaves the device unless you explicitly use the Data
 menu to export a JSON backup.
+
+The one exception is **Progress → Symmetry**, which calls the public, read-only
+[FitnessVolt Strength Standards API](https://fitnessvolt.com/strength-standards/developers/)
+to score your lifts against population data. It sends only a lift slug, an
+estimated 1RM, bodyweight, sex, and (optionally) age — no identifying data — and
+caches every response in `localStorage` (`mgym.fvCache.v1`) so repeat views work
+offline. The call is on-demand (only when that view is open) and degrades
+gracefully when offline; the rest of the app never touches the network. Client
+in `src/lib/fvApi.js`.
 
 The UI is a single centered column navigated by a **fixed five-tab bottom bar** —
 **Home**, **Workouts**, **Progress**, **Exercises**, **More**. There is no
@@ -145,9 +154,10 @@ main.jsx
                     │   ├── (list) WorkoutHistory → WorkoutHistoryItem  (▶ Start → live session)
                     │   └── (calendar) CalendarView → AddExerciseInput
                     │
-                    ├── [tab="progress"]  Progress        (Segmented: Bodyweight | Strength)
+                    ├── [tab="progress"]  Progress        (Segmented: Bodyweight | Strength | Symmetry)
                     │   ├── (bodyweight) WeightTracker → WeightChart
-                    │   └── (strength)   StrengthAnalysis
+                    │   ├── (strength)   StrengthAnalysis
+                    │   └── (symmetry)   StrengthStandards  (Recharts radar; FitnessVolt API)
                     │                         ├── MultiLineChart  (muscle trend + exercise curve)
                     │                         ├── Delta
                     │                         └── ComboInput      (exercise picker)

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -157,10 +157,11 @@ main.jsx
                     ├── [tab="progress"]  Progress        (Segmented: Bodyweight | Strength | Symmetry)
                     │   ├── (bodyweight) WeightTracker → WeightChart
                     │   ├── (strength)   StrengthAnalysis
+                    │   │                     ├── MultiLineChart  (muscle trend + exercise curve)
+                    │   │                     ├── Delta
+                    │   │                     └── ComboInput      (exercise picker)
                     │   └── (symmetry)   StrengthStandards  (Recharts radar; FitnessVolt API)
-                    │                         ├── MultiLineChart  (muscle trend + exercise curve)
-                    │                         ├── Delta
-                    │                         └── ComboInput      (exercise picker)
+                    │                         └── LiftRatioBalance  (symmetry score; FitnessVolt p50 standards)
                     │
                     ├── [tab="exercises"] ExerciseManager (search + muscle-group chips)
                     │   ├── NewExerciseInline → ComboInput

--- a/docs/DATA-MODEL.md
+++ b/docs/DATA-MODEL.md
@@ -21,7 +21,7 @@ versioned, and that is the only versioning.
 | `mgym.note.v1`             | `Notepad` (`K_NOTE`)       | `string` — global note                                                                   | `""`                                             |
 | `weightLogs`               | `WeightTracker`            | `{ [YYYY-MM-DD]: number }` — bodyweight                                                  | `{}`                                             |
 | `mgym.profile.v1`          | `MoreMenu`                 | `{ sex?: "male"\|"female", birthYear?: number }` — lifter profile for strength standards | `{}`                                             |
-| `mgym.fvCache.v1`          | `fvApi`                    | cache of FitnessVolt percentile responses, keyed by lift/sex/age/unit/weight/bodyweight  | `{}`                                             |
+| `mgym.fvCache.v1`          | `fvApi`                    | cache of FitnessVolt percentile + standards responses (see below)                        | `{}`                                             |
 | `weekly-note:<weekKey>`    | _legacy_ (no longer used)  | `string` — one note per ISO week (written by the removed `WeeklyNotes`)                  | `""`                                             |
 | `summary-open:<periodKey>` | _legacy_ (no longer used)  | `boolean` — card collapse state (written by the removed `PeriodCard`)                    | card default                                     |
 
@@ -182,10 +182,17 @@ Profile**, self-persisted (not part of the backup payload, not in `AppContext`).
 
 ### Strength-standards cache (`mgym.fvCache.v1`)
 
-A response cache for the only external API the app calls (FitnessVolt). Keys are
-`lift|sex|age|unit|weight|bodyweight` with weight/bodyweight rounded to 0.5 kg;
-values are `{ verified, gym }` percentile objects. Purely a network cache — safe
-to clear, rebuilt on demand. Not in the backup payload. See `src/lib/fvApi.js`.
+A response cache for the only external API the app calls (FitnessVolt). It holds
+two kinds of entry, both rounded to 0.5 kg:
+
+- **Percentile lookups** — key `lift|sex|age|unit|weight|bodyweight`, value
+  `{ verified, gym }` percentile objects (the radar + per-axis breakdown).
+- **Standards lookups** — key `std|lift|sex|source|age|unit|bodyweight`, value
+  `{ percentiles, p50, bwMultiple }`. The `p50` (median lift) feeds the Lift
+  Balance panel's empirical ratio benchmarks.
+
+Purely a network cache — safe to clear, rebuilt on demand. Not in the backup
+payload. See `src/lib/fvApi.js`.
 
 ### Notes
 

--- a/docs/DATA-MODEL.md
+++ b/docs/DATA-MODEL.md
@@ -10,18 +10,20 @@ versioned, and that is the only versioning.
 
 ## localStorage keys
 
-| Key                        | Written by                 | Holds                                                                                | Default when absent                              |
-| -------------------------- | -------------------------- | ------------------------------------------------------------------------------------ | ------------------------------------------------ |
-| `mgym.exercises.v1`        | `AppContext` (`K_EX`)      | `Exercise[]`                                                                         | the 76-entry seed `src/data/exercises_seed.json` |
-| `mgym.workouts.v1`         | `AppContext` (`K_WO`)      | `Workout[]`                                                                          | `[]`                                             |
-| `mgym.unit`                | `AppContext` (`K_UNIT`)    | `"kg"` \| `"lb"` (toggle UI hidden; effectively `"kg"`)                              | `"kg"`                                           |
-| `mgym.tab`                 | `AppContext` (`K_TAB`)     | active tab: `home`/`workouts`/`progress`/`exercises`/`more` (legacy values remapped) | `"workouts"`                                     |
-| `mgym.theme`               | `AppContext` (`K_THEME`)   | `"system"` \| `"light"` \| `"dark"`                                                  | `"system"`                                       |
-| `mgym.session.v1`          | `AppContext` (`K_SESSION`) | live-logging session object, or `null`                                               | `null`                                           |
-| `mgym.note.v1`             | `Notepad` (`K_NOTE`)       | `string` — global note                                                               | `""`                                             |
-| `weightLogs`               | `WeightTracker`            | `{ [YYYY-MM-DD]: number }` — bodyweight                                              | `{}`                                             |
-| `weekly-note:<weekKey>`    | _legacy_ (no longer used)  | `string` — one note per ISO week (written by the removed `WeeklyNotes`)              | `""`                                             |
-| `summary-open:<periodKey>` | _legacy_ (no longer used)  | `boolean` — card collapse state (written by the removed `PeriodCard`)                | card default                                     |
+| Key                        | Written by                 | Holds                                                                                    | Default when absent                              |
+| -------------------------- | -------------------------- | ---------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| `mgym.exercises.v1`        | `AppContext` (`K_EX`)      | `Exercise[]`                                                                             | the 76-entry seed `src/data/exercises_seed.json` |
+| `mgym.workouts.v1`         | `AppContext` (`K_WO`)      | `Workout[]`                                                                              | `[]`                                             |
+| `mgym.unit`                | `AppContext` (`K_UNIT`)    | `"kg"` \| `"lb"` (toggle UI hidden; effectively `"kg"`)                                  | `"kg"`                                           |
+| `mgym.tab`                 | `AppContext` (`K_TAB`)     | active tab: `home`/`workouts`/`progress`/`exercises`/`more` (legacy values remapped)     | `"workouts"`                                     |
+| `mgym.theme`               | `AppContext` (`K_THEME`)   | `"system"` \| `"light"` \| `"dark"`                                                      | `"system"`                                       |
+| `mgym.session.v1`          | `AppContext` (`K_SESSION`) | live-logging session object, or `null`                                                   | `null`                                           |
+| `mgym.note.v1`             | `Notepad` (`K_NOTE`)       | `string` — global note                                                                   | `""`                                             |
+| `weightLogs`               | `WeightTracker`            | `{ [YYYY-MM-DD]: number }` — bodyweight                                                  | `{}`                                             |
+| `mgym.profile.v1`          | `MoreMenu`                 | `{ sex?: "male"\|"female", birthYear?: number }` — lifter profile for strength standards | `{}`                                             |
+| `mgym.fvCache.v1`          | `fvApi`                    | cache of FitnessVolt percentile responses, keyed by lift/sex/age/unit/weight/bodyweight  | `{}`                                             |
+| `weekly-note:<weekKey>`    | _legacy_ (no longer used)  | `string` — one note per ISO week (written by the removed `WeeklyNotes`)                  | `""`                                             |
+| `summary-open:<periodKey>` | _legacy_ (no longer used)  | `boolean` — card collapse state (written by the removed `PeriodCard`)                    | card default                                     |
 
 All values are stored with `JSON.stringify`. String values (the notes) are
 stored as JSON strings (e.g. the literal `""`).
@@ -166,6 +168,24 @@ A flat map used by the Weight tab:
 > bodyweight in lb, the **toggle UI is currently hidden** and the app shows kg
 > only. Weekly averages and the Progress "Avg Weight" KPI are computed directly
 > from these numbers.
+
+### Lifter profile (`mgym.profile.v1`)
+
+Optional self-reported data the **Progress → Symmetry** view needs to score
+lifts against the FitnessVolt Strength Standards API. Authored in **More →
+Profile**, self-persisted (not part of the backup payload, not in `AppContext`).
+
+| Field       | Type                   | Purpose                                          |
+| ----------- | ---------------------- | ------------------------------------------------ |
+| `sex`       | `"male"` \| `"female"` | Required by the standards API; absent until set. |
+| `birthYear` | `number` (optional)    | Sharpens the gym age cohort; omitted when blank. |
+
+### Strength-standards cache (`mgym.fvCache.v1`)
+
+A response cache for the only external API the app calls (FitnessVolt). Keys are
+`lift|sex|age|unit|weight|bodyweight` with weight/bodyweight rounded to 0.5 kg;
+values are `{ verified, gym }` percentile objects. Purely a network cache — safe
+to clear, rebuilt on demand. Not in the backup payload. See `src/lib/fvApi.js`.
 
 ### Notes
 

--- a/src/components/LiftRatioBalance.jsx
+++ b/src/components/LiftRatioBalance.jsx
@@ -1,0 +1,274 @@
+// src/components/LiftRatioBalance.jsx
+// Progress → Symmetry "Lift Balance" panel — a take on FitnessVolt's Strength
+// Symmetry Analyzer. It compares the ratios between your main barbell lifts
+// (each vs your squat) to the ratios of the median lifter at your bodyweight,
+// derived from the API's p50 standards rather than hard-coded "ideal" numbers.
+
+import React, { useEffect, useMemo, useState } from "react";
+import {
+  RATIO_LIFTS,
+  RATIO_BASE,
+  RATIO_BASE_LABEL,
+  buildRatioRows,
+  overallScore,
+  scoreRating,
+  focusAreas,
+} from "../lib/liftRatios";
+import { fetchStandards } from "../lib/fvApi";
+
+const pct = (r) => `${Math.round(r * 100)}%`;
+const signed = (n) => `${n >= 0 ? "+" : ""}${n}%`;
+
+function Notice({ children }) {
+  return (
+    <div className="rounded-lg border border-dashed p-4 text-sm text-neutral-600 dark:border-neutral-700 dark:text-neutral-300">
+      {children}
+    </div>
+  );
+}
+
+const BADGE = {
+  balanced:
+    "bg-emerald-50 text-emerald-700 dark:bg-emerald-500/10 dark:text-emerald-400",
+  weak: "bg-rose-50 text-rose-700 dark:bg-rose-500/10 dark:text-rose-400",
+  strong: "bg-sky-50 text-sky-700 dark:bg-sky-500/10 dark:text-sky-400",
+};
+const BADGE_LABEL = {
+  balanced: "Balanced",
+  weak: "Lagging",
+  strong: "Leading",
+};
+
+function AssessBadge({ assessment }) {
+  return (
+    <span
+      className={`rounded-full px-2 py-0.5 text-[11px] font-medium ${BADGE[assessment]}`}
+    >
+      {BADGE_LABEL[assessment]}
+    </span>
+  );
+}
+
+export default function LiftRatioBalance({
+  e1rmBySlug,
+  bodyweight,
+  sex,
+  age,
+  refreshNonce = 0,
+}) {
+  // User e1RM (kg) keyed by ratio-lift key, for lifts actually logged.
+  const userByKey = useMemo(() => {
+    const out = {};
+    for (const lift of RATIO_LIFTS) {
+      const v = Number(e1rmBySlug?.[lift.slug]);
+      if (Number.isFinite(v) && v > 0) out[lift.key] = v;
+    }
+    return out;
+  }, [e1rmBySlug]);
+
+  const presentLifts = RATIO_LIFTS.filter((l) => l.key in userByKey);
+  const hasBase = RATIO_BASE in userByKey;
+  const canQuery = hasBase && presentLifts.length >= 2;
+
+  const reqKey = JSON.stringify({
+    sex,
+    age,
+    bw: Math.round(Number(bodyweight) || 0),
+    keys: Object.keys(userByKey).sort(),
+  });
+
+  const [state, setState] = useState({
+    loading: false,
+    error: null,
+    avg: null,
+  });
+
+  useEffect(() => {
+    if (!canQuery) return;
+    let cancelled = false;
+    // Flagging the in-flight fetch (external-system sync) — documented exception.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setState((s) => ({ ...s, loading: true, error: null }));
+
+    const reqs = presentLifts.map((l) => ({
+      key: l.key,
+      lift: l.slug,
+      bodyweight,
+      sex,
+      age,
+      source: "gym",
+    }));
+
+    fetchStandards(reqs, { cache: refreshNonce === 0 })
+      .then((res) => {
+        if (cancelled) return;
+        const avg = {};
+        for (const l of presentLifts) {
+          const r = res[l.key];
+          if (r && !r.error && r.p50 != null) avg[l.key] = r.p50;
+        }
+        const anyError = Object.values(res).some((r) => r?.error);
+        setState({
+          loading: false,
+          error: anyError ? "Some standards couldn't be loaded." : null,
+          avg,
+        });
+      })
+      .catch((e) => {
+        if (!cancelled) {
+          setState({
+            loading: false,
+            error: e?.message || "Lookup failed.",
+            avg: null,
+          });
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [reqKey, refreshNonce, canQuery]);
+
+  // --- Gating --------------------------------------------------------------
+  if (!hasBase) {
+    return (
+      <Notice>
+        Log a <span className="font-medium">Back Squat</span> to see lift
+        balance — every ratio is measured against your squat.
+      </Notice>
+    );
+  }
+  if (presentLifts.length < 2) {
+    return (
+      <Notice>
+        Log at least one more big lift (Bench, Deadlift, Overhead Press or
+        Barbell Row) alongside your squat to compare lift balance.
+      </Notice>
+    );
+  }
+
+  const { loading, error, avg } = state;
+  const rows = buildRatioRows(userByKey, avg || {});
+  const score = overallScore(rows);
+  const rating = scoreRating(score);
+  const { weakest, strongest } = focusAreas(rows);
+
+  return (
+    <div className="space-y-3">
+      <div className="text-xs uppercase tracking-wide text-neutral-400">
+        Lift balance
+      </div>
+
+      {/* Overall symmetry score */}
+      <div className="rounded-xl border p-4 dark:border-neutral-800">
+        {loading && !avg ? (
+          <div className="py-6 text-center text-sm text-neutral-500 dark:text-neutral-400">
+            Loading strength standards…
+          </div>
+        ) : score == null ? (
+          <div className="text-sm text-neutral-500 dark:text-neutral-400">
+            Couldn’t compute a balance score yet.
+          </div>
+        ) : (
+          <>
+            <div className="flex items-end justify-between gap-3">
+              <div>
+                <div className="text-xs uppercase tracking-wide text-neutral-400">
+                  Symmetry score
+                </div>
+                <div className="mt-0.5 text-3xl font-semibold text-neutral-900 dark:text-neutral-100">
+                  {score}
+                  <span className="text-lg text-neutral-400"> / 100</span>
+                </div>
+              </div>
+              <div className="text-right">
+                <div className="text-lg font-semibold text-neutral-800 dark:text-neutral-200">
+                  {rating}
+                </div>
+                <div className="text-[11px] text-neutral-500 dark:text-neutral-400">
+                  vs the median lifter
+                </div>
+              </div>
+            </div>
+
+            {(weakest || strongest) && (
+              <div className="mt-3 grid gap-2 sm:grid-cols-2">
+                {weakest && (
+                  <div className="rounded-lg bg-rose-50 px-3 py-2 text-xs text-rose-700 dark:bg-rose-500/10 dark:text-rose-400">
+                    <span className="font-medium">{weakest.label}</span> lags
+                    your squat — a good place to push.
+                  </div>
+                )}
+                {strongest && (
+                  <div className="rounded-lg bg-sky-50 px-3 py-2 text-xs text-sky-700 dark:bg-sky-500/10 dark:text-sky-400">
+                    <span className="font-medium">{strongest.label}</span> leads
+                    relative to your squat.
+                  </div>
+                )}
+              </div>
+            )}
+          </>
+        )}
+      </div>
+
+      {error && (
+        <div className="text-xs text-amber-600 dark:text-amber-400">
+          {error}
+        </div>
+      )}
+
+      {/* Ratio breakdown */}
+      {rows.length > 0 && (
+        <div className="overflow-hidden rounded-xl border text-sm dark:border-neutral-800">
+          <div className="grid grid-cols-[1fr_auto_auto_auto] items-center gap-2 bg-neutral-50 px-3 py-2 text-[11px] uppercase tracking-wide text-neutral-400 dark:bg-neutral-800/60">
+            <span>Lift</span>
+            <span className="text-right">Yours</span>
+            <span className="text-right">Median</span>
+            <span className="text-right">Balance</span>
+          </div>
+          <div className="divide-y dark:divide-neutral-800">
+            {rows.map((r) => {
+              const diffPts = Math.round(r.diff * 100);
+              return (
+                <div
+                  key={r.key}
+                  className="grid grid-cols-[1fr_auto_auto_auto] items-center gap-2 px-3 py-2"
+                >
+                  <div className="min-w-0">
+                    <div className="truncate font-medium text-neutral-900 dark:text-neutral-100">
+                      {r.label}
+                    </div>
+                    <div className="text-[11px] text-neutral-400">
+                      vs {RATIO_BASE_LABEL}
+                    </div>
+                  </div>
+                  <div className="text-right font-semibold tabular-nums">
+                    {pct(r.userRatio)}
+                  </div>
+                  <div className="text-right tabular-nums text-neutral-500 dark:text-neutral-400">
+                    {pct(r.avgRatio)}
+                  </div>
+                  <div className="flex flex-col items-end gap-0.5">
+                    <AssessBadge assessment={r.assessment} />
+                    {r.assessment !== "balanced" && (
+                      <span className="text-[11px] tabular-nums text-neutral-400">
+                        {signed(diffPts)}
+                      </span>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      <p className="px-1 text-[11px] leading-snug text-neutral-400 dark:text-neutral-500">
+        Each lift is shown as a percentage of your {RATIO_BASE_LABEL}. “Median”
+        is the typical lifter at your bodyweight and sex (FitnessVolt gym data);
+        within 5% counts as balanced.
+      </p>
+    </div>
+  );
+}

--- a/src/components/LiftRatioBalance.test.jsx
+++ b/src/components/LiftRatioBalance.test.jsx
@@ -1,0 +1,72 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { beforeEach, vi } from "vitest";
+import LiftRatioBalance from "./LiftRatioBalance";
+
+const fetchStandards = vi.fn();
+vi.mock("../lib/fvApi", () => ({
+  fetchStandards: (...args) => fetchStandards(...args),
+}));
+
+// Median p50 lifts: squat 110, bench 82, deadlift 132 (real-ish male @70kg).
+const P50 = { squat: 110, bench: 82, deadlift: 132 };
+
+beforeEach(() => {
+  fetchStandards.mockReset();
+  fetchStandards.mockImplementation(async (reqs) => {
+    const out = {};
+    for (const r of reqs) out[r.key] = { p50: P50[r.key] ?? null };
+    return out;
+  });
+});
+
+const props = { bodyweight: 70, sex: "male", age: 30 };
+
+describe("LiftRatioBalance gating", () => {
+  it("asks for a squat when none is logged", () => {
+    render(<LiftRatioBalance {...props} e1rmBySlug={{ bench_press: 80 }} />);
+    expect(screen.getByText(/back squat/i)).toBeInTheDocument();
+    expect(fetchStandards).not.toHaveBeenCalled();
+  });
+
+  it("asks for a second lift when only the squat is logged", () => {
+    render(<LiftRatioBalance {...props} e1rmBySlug={{ back_squat: 110 }} />);
+    expect(screen.getByText(/at least one more big lift/i)).toBeInTheDocument();
+    expect(fetchStandards).not.toHaveBeenCalled();
+  });
+});
+
+describe("LiftRatioBalance scoring", () => {
+  it("scores a median-proportioned lifter at 100 and labels lifts balanced", async () => {
+    render(
+      <LiftRatioBalance
+        {...props}
+        e1rmBySlug={{ back_squat: 110, bench_press: 82, deadlift: 132 }}
+      />,
+    );
+    expect(await screen.findByText("100")).toBeInTheDocument();
+    expect(screen.getByText("Excellent")).toBeInTheDocument();
+    // Both non-base lifts read as balanced; squat is the reference, not a row.
+    expect(screen.getAllByText("Balanced").length).toBe(2);
+    expect(screen.getByText("Bench Press")).toBeInTheDocument();
+    expect(screen.getByText("Deadlift")).toBeInTheDocument();
+    expect(screen.queryByText("Squat")).not.toBeInTheDocument();
+  });
+
+  it("flags a lagging lift and queries the right standards slugs", async () => {
+    render(
+      <LiftRatioBalance
+        {...props}
+        // Bench is well below its median share of the squat -> lagging.
+        e1rmBySlug={{ back_squat: 110, bench_press: 50 }}
+      />,
+    );
+    expect(await screen.findByText("Lagging")).toBeInTheDocument();
+    const reqs = fetchStandards.mock.calls[0][0];
+    expect(reqs.map((r) => r.lift).sort()).toEqual([
+      "back_squat",
+      "bench_press",
+    ]);
+    expect(reqs[0]).toMatchObject({ sex: "male", age: 30, source: "gym" });
+  });
+});

--- a/src/components/MoreMenu.jsx
+++ b/src/components/MoreMenu.jsx
@@ -1,8 +1,10 @@
 import React, { useState } from "react";
 import { useApp } from "../context/AppContext";
 import Segmented from "./ui/Segmented";
+import { Input } from "./ui/Input";
 import Notepad from "./Notepad";
 import DataManagementMenu from "./DataManagementMenu";
+import { loadLS, saveLS, K_PROFILE } from "../lib/storage";
 
 /**
  * "More" destination — a settings hub for everything that doesn't warrant its
@@ -21,6 +23,17 @@ function SectionLabel({ children }) {
 export default function MoreMenu() {
   const { theme, setTheme } = useApp();
   const [view, setView] = useState("menu");
+
+  // Lifter profile (sex + birth year) for the Progress -> Symmetry view's
+  // strength-standards lookups. Self-persisted like the Notepad/Weight logs.
+  const [profile, setProfile] = useState(() => loadLS(K_PROFILE, {}));
+  const updateProfile = (patch) => {
+    setProfile((prev) => {
+      const next = { ...prev, ...patch };
+      saveLS(K_PROFILE, next);
+      return next;
+    });
+  };
 
   if (view === "notepad") {
     return (
@@ -73,6 +86,52 @@ export default function MoreMenu() {
             />
           </div>
         </div>
+      </div>
+
+      {/* Profile — feeds the Progress → Symmetry strength standards */}
+      <div>
+        <SectionLabel>Profile</SectionLabel>
+        <div className={`${card} divide-y dark:divide-neutral-800`}>
+          <div className="flex items-center justify-between px-3 py-3">
+            <span className={rowText}>Sex</span>
+            <Segmented
+              options={[
+                ["male", "Male"],
+                ["female", "Female"],
+              ]}
+              value={profile.sex || ""}
+              onChange={(sex) => updateProfile({ sex })}
+            />
+          </div>
+          <div className="flex items-center justify-between gap-3 px-3 py-3">
+            <div>
+              <div className={rowText}>Birth year</div>
+              <div className="text-[11px] text-neutral-500 dark:text-neutral-400">
+                Optional — sharpens your age cohort
+              </div>
+            </div>
+            <div className="w-24">
+              <Input
+                type="number"
+                inputMode="numeric"
+                placeholder="1996"
+                min="1900"
+                max="2020"
+                value={profile.birthYear ?? ""}
+                onChange={(e) => {
+                  const v = e.target.value.trim();
+                  updateProfile({
+                    birthYear: v === "" ? undefined : Number(v),
+                  });
+                }}
+              />
+            </div>
+          </div>
+        </div>
+        <p className="mt-1 px-1 text-[11px] text-neutral-400 dark:text-neutral-500">
+          Used only to compare your lifts against strength standards. Stays on
+          this device.
+        </p>
       </div>
 
       {/* Content */}

--- a/src/components/Progress.jsx
+++ b/src/components/Progress.jsx
@@ -2,14 +2,22 @@ import React, { useState } from "react";
 import Segmented from "./ui/Segmented";
 import WeightTracker from "./WeightTracker";
 import StrengthAnalysis from "./StrengthAnalysis";
+import StrengthStandards from "./StrengthStandards";
 
 /**
  * Progress destination. Merges the former Weight and Summary tabs:
  * "Bodyweight" shows the bodyweight calendar + trend, "Strength" shows the
- * strength-analysis dashboard (progression, PRs, volume-by-muscle).
+ * strength-analysis dashboard (progression, PRs, volume-by-muscle), and
+ * "Symmetry" scores lifts against external strength standards (radar).
  */
 export default function Progress() {
   const [view, setView] = useState("bodyweight");
+
+  const body = {
+    bodyweight: <WeightTracker />,
+    strength: <StrengthAnalysis />,
+    symmetry: <StrengthStandards />,
+  };
 
   return (
     <div className="space-y-4">
@@ -21,13 +29,14 @@ export default function Progress() {
           options={[
             ["bodyweight", "Bodyweight"],
             ["strength", "Strength"],
+            ["symmetry", "Symmetry"],
           ]}
           value={view}
           onChange={setView}
         />
       </div>
 
-      {view === "bodyweight" ? <WeightTracker /> : <StrengthAnalysis />}
+      {body[view]}
     </div>
   );
 }

--- a/src/components/StrengthStandards.jsx
+++ b/src/components/StrengthStandards.jsx
@@ -30,6 +30,7 @@ import {
   starsFromPercentile,
 } from "../lib/strengthStandards";
 import { fetchPercentiles, FV_ATTRIBUTION_URL } from "../lib/fvApi";
+import LiftRatioBalance from "./LiftRatioBalance";
 
 const NOW_COLOR = "#378ADD";
 const PAST_COLOR = "#D4537E";
@@ -98,9 +99,11 @@ export default function StrengthStandards() {
   const bwNow = bodyweightAsOf(weightLogs);
   const bwPast = bodyweightAsOf(weightLogs, pastDate) ?? bwNow;
 
+  // Best current e1RM per slug — feeds both the radar and the lift-balance panel.
+  const e1rmNow = useMemo(() => bestE1RMBySlug(wos), [wos]);
+
   // Build the per-axis lookup requests for both snapshots.
   const { nowReqs, pastReqs, verifiedReqs } = useMemo(() => {
-    const e1rmNow = bestE1RMBySlug(wos);
     const e1rmPast = bestE1RMBySlug(wos, pastDate);
     const now = axisRequests(e1rmNow, bwNow);
     const past = axisRequests(e1rmPast, bwPast);
@@ -119,7 +122,7 @@ export default function StrengthStandards() {
       });
     }
     return { nowReqs: now, pastReqs: past, verifiedReqs: verified };
-  }, [wos, pastDate, bwNow, bwPast]);
+  }, [wos, e1rmNow, pastDate, bwNow, bwPast]);
 
   const [state, setState] = useState({
     loading: false,
@@ -327,12 +330,18 @@ export default function StrengthStandards() {
                 isAnimationActive={false}
               />
               <Tooltip
-                formatter={(v) => (v == null ? "—" : `${Math.round(v)}%ile`)}
+                formatter={(v) => (v == null ? "—" : `${Math.round(v)}%`)}
               />
               <Legend wrapperStyle={{ fontSize: 12 }} />
             </RadarChart>
           </ResponsiveContainer>
         )}
+        <p className="px-2 pb-1 pt-2 text-center text-[11px] leading-snug text-neutral-500 dark:text-neutral-400">
+          Each axis is your percentile against other{" "}
+          {sex === "female" ? "women" : "men"} at ~{Math.round(bwNow)} kg
+          bodyweight{age ? `, age ${age}` : ""} in the FitnessVolt gym dataset.
+          A higher value means you out-lift more people; 50% is the median.
+        </p>
       </div>
 
       {/* Per-axis breakdown */}
@@ -394,6 +403,15 @@ export default function StrengthStandards() {
           })}
         </div>
       </div>
+
+      {/* Lift-ratio balance (Symmetry Analyzer) */}
+      <LiftRatioBalance
+        e1rmBySlug={e1rmNow}
+        bodyweight={bwNow}
+        sex={sex}
+        age={age}
+        refreshNonce={refreshNonce}
+      />
 
       <p className="px-1 text-center text-[11px] text-neutral-400 dark:text-neutral-500">
         <a

--- a/src/components/StrengthStandards.jsx
+++ b/src/components/StrengthStandards.jsx
@@ -1,0 +1,412 @@
+// src/components/StrengthStandards.jsx
+// Progress → Symmetry: a strengthlevel-style radar that scores your best lifts
+// against the FitnessVolt Strength Standards API, with a "now vs a past date"
+// comparison. The radar (gym source) is movement-based; verified
+// (OpenPowerlifting) percentiles are shown as a bonus for squat/bench/deadlift.
+
+import React, { useEffect, useMemo, useState } from "react";
+import {
+  ResponsiveContainer,
+  RadarChart,
+  PolarGrid,
+  PolarAngleAxis,
+  PolarRadiusAxis,
+  Radar,
+  Legend,
+  Tooltip,
+} from "recharts";
+import { useApp } from "../context/AppContext";
+import { Input } from "./ui/Input";
+import { loadLS, K_PROFILE, K_WEIGHT_LOGS } from "../lib/storage";
+import { ymdFromDate } from "../lib/date";
+import {
+  RADAR_AXES,
+  bestE1RMBySlug,
+  axisRequests,
+  liftWeight,
+  ageFromBirthYear,
+  percentileToTier,
+  overallTier,
+  starsFromPercentile,
+} from "../lib/strengthStandards";
+import { fetchPercentiles, FV_ATTRIBUTION_URL } from "../lib/fvApi";
+
+const NOW_COLOR = "#378ADD";
+const PAST_COLOR = "#D4537E";
+
+const cap = (s) => (s ? s.charAt(0).toUpperCase() + s.slice(1) : s);
+
+// Most recent logged bodyweight (kg) on or before a date, else the latest.
+function bodyweightAsOf(logs, onOrBefore = null) {
+  const keys = Object.keys(logs || {})
+    .filter((k) => !onOrBefore || k <= onOrBefore)
+    .sort();
+  for (let i = keys.length - 1; i >= 0; i--) {
+    const v = logs[keys[i]];
+    if (typeof v === "number" && Number.isFinite(v)) return v;
+  }
+  return null;
+}
+
+function Stars({ percentile }) {
+  const n = starsFromPercentile(percentile);
+  return (
+    <span aria-label={`${n} of 5 stars`} className="text-lg tracking-tight">
+      <span className="text-amber-400">{"★".repeat(n)}</span>
+      <span className="text-neutral-300 dark:text-neutral-600">
+        {"★".repeat(5 - n)}
+      </span>
+    </span>
+  );
+}
+
+function TierBadge({ tier }) {
+  if (!tier) return <span className="text-neutral-400">—</span>;
+  return (
+    <span className="rounded-full bg-neutral-100 px-2 py-0.5 text-[11px] font-medium text-neutral-700 dark:bg-neutral-800 dark:text-neutral-300">
+      {cap(tier)}
+    </span>
+  );
+}
+
+function Notice({ children }) {
+  return (
+    <div className="rounded-lg border border-dashed p-4 text-sm text-neutral-600 dark:border-neutral-700 dark:text-neutral-300">
+      {children}
+    </div>
+  );
+}
+
+export default function StrengthStandards() {
+  const { workouts } = useApp();
+  const wos = useMemo(() => workouts || [], [workouts]);
+
+  const profile = useMemo(() => loadLS(K_PROFILE, {}), []);
+  const weightLogs = useMemo(() => loadLS(K_WEIGHT_LOGS, {}), []);
+  const sex = profile.sex;
+  const age = ageFromBirthYear(profile.birthYear);
+
+  // Default the comparison date to ~6 months ago.
+  const defaultPast = useMemo(() => {
+    const d = new Date();
+    d.setMonth(d.getMonth() - 6);
+    return ymdFromDate(d);
+  }, []);
+  const [pastDate, setPastDate] = useState(defaultPast);
+  const [refreshNonce, setRefreshNonce] = useState(0);
+
+  const bwNow = bodyweightAsOf(weightLogs);
+  const bwPast = bodyweightAsOf(weightLogs, pastDate) ?? bwNow;
+
+  // Build the per-axis lookup requests for both snapshots.
+  const { nowReqs, pastReqs, verifiedReqs } = useMemo(() => {
+    const e1rmNow = bestE1RMBySlug(wos);
+    const e1rmPast = bestE1RMBySlug(wos, pastDate);
+    const now = axisRequests(e1rmNow, bwNow);
+    const past = axisRequests(e1rmPast, bwPast);
+    // Verified bonus: only squat/bench/deadlift, scored from each axis's
+    // canonical (first) slug, "now" snapshot only.
+    const verified = [];
+    for (const axis of RADAR_AXES) {
+      if (!axis.verified) continue;
+      const slug = axis.slugs[0];
+      if (!(slug in e1rmNow)) continue;
+      verified.push({
+        key: axis.key,
+        lift: axis.verified,
+        weight: liftWeight(slug, e1rmNow[slug], bwNow),
+        bodyweight: bwNow,
+      });
+    }
+    return { nowReqs: now, pastReqs: past, verifiedReqs: verified };
+  }, [wos, pastDate, bwNow, bwPast]);
+
+  const [state, setState] = useState({
+    loading: false,
+    error: null,
+    data: null,
+  });
+
+  const canQuery = Boolean(sex) && bwNow != null && nowReqs.length > 0;
+
+  // Serialize the request shape so the effect only refetches on real changes.
+  const reqKey = JSON.stringify({ sex, age, nowReqs, pastReqs, verifiedReqs });
+
+  useEffect(() => {
+    if (!canQuery) return;
+    let cancelled = false;
+    // Flagging the in-flight fetch is the documented exception to this rule
+    // (synchronizing with an external system on mount/dep-change).
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setState((s) => ({ ...s, loading: true, error: null }));
+
+    const opts = { cache: refreshNonce === 0 ? true : false };
+    const req = (src, key, lift, weight, bodyweight) => ({
+      key: `${src}:${key}`,
+      lift,
+      weight,
+      bodyweight,
+      sex,
+      age,
+    });
+
+    const all = [
+      ...nowReqs.map((r) => req("now", r.axis, r.slug, r.weight, bwNow)),
+      ...pastReqs.map((r) => req("past", r.axis, r.slug, r.weight, bwPast)),
+      ...verifiedReqs.map((r) =>
+        req("ver", r.key, r.lift, r.weight, r.bodyweight),
+      ),
+    ];
+
+    fetchPercentiles(all, opts)
+      .then((res) => {
+        if (cancelled) return;
+        const data = { now: {}, past: {}, verified: {} };
+        for (const axis of RADAR_AXES) {
+          const n = res[`now:${axis.key}`];
+          const p = res[`past:${axis.key}`];
+          const v = res[`ver:${axis.key}`];
+          if (n && !n.error) data.now[axis.key] = n.gym;
+          if (p && !p.error) data.past[axis.key] = p.gym;
+          if (v && !v.error) data.verified[axis.key] = v.verified;
+        }
+        const anyError = Object.values(res).some((r) => r?.error);
+        setState({
+          loading: false,
+          error: anyError ? "Some standards couldn't be loaded." : null,
+          data,
+        });
+      })
+      .catch((e) => {
+        if (!cancelled) {
+          setState({
+            loading: false,
+            error: e?.message || "Lookup failed.",
+            data: null,
+          });
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+    // reqKey captures sex/age/requests; refreshNonce forces a cache-bypassing refetch.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [reqKey, refreshNonce, canQuery]);
+
+  // --- Gating states -------------------------------------------------------
+  if (!sex) {
+    return (
+      <Notice>
+        Set your <span className="font-medium">sex</span> in{" "}
+        <span className="font-medium">More → Profile</span> to compare your
+        lifts against strength standards.
+      </Notice>
+    );
+  }
+  if (bwNow == null) {
+    return (
+      <Notice>
+        Log your <span className="font-medium">bodyweight</span> in{" "}
+        <span className="font-medium">Progress → Bodyweight</span> first —
+        strength standards are relative to bodyweight.
+      </Notice>
+    );
+  }
+  if (nowReqs.length === 0) {
+    return (
+      <Notice>
+        No standard barbell lifts logged yet. Log lifts like{" "}
+        <span className="font-medium">
+          Squat, Bench Press, Deadlift, Shoulder Press, Pull-up or Bent-over Row
+        </span>{" "}
+        to see your strength symmetry.
+      </Notice>
+    );
+  }
+
+  const { loading, error, data } = state;
+
+  // --- Derived view data ---------------------------------------------------
+  const axesWithData = RADAR_AXES.filter((a) => data?.now?.[a.key]);
+  const radarData = axesWithData.map((a) => ({
+    axis: a.label,
+    now: data.now[a.key]?.percentile ?? null,
+    past: data.past?.[a.key]?.percentile ?? null,
+  }));
+  const hasPast = radarData.some((r) => r.past != null);
+
+  const nowPercentiles = axesWithData.map((a) => data.now[a.key]?.percentile);
+  const avgNow =
+    nowPercentiles.filter((p) => p != null).reduce((a, b) => a + b, 0) /
+    (nowPercentiles.filter((p) => p != null).length || 1);
+  const overall = overallTier(nowPercentiles);
+
+  return (
+    <div className="space-y-5">
+      {/* Header: overall level + stars */}
+      <div className="rounded-xl border p-4 dark:border-neutral-800">
+        <div className="text-xs uppercase tracking-wide text-neutral-400">
+          Your strength level
+        </div>
+        <div className="mt-0.5 flex items-center justify-between gap-3">
+          <div className="text-2xl font-semibold text-neutral-900 dark:text-neutral-100">
+            {overall ? cap(overall) : "—"}
+          </div>
+          <Stars percentile={Number.isFinite(avgNow) ? avgNow : 0} />
+        </div>
+        <div className="mt-1 text-xs text-neutral-500 dark:text-neutral-400">
+          Across {axesWithData.length} of {RADAR_AXES.length} lift groups
+          {age ? `, age ${age}` : ""} · {Math.round(bwNow)} kg bodyweight
+        </div>
+      </div>
+
+      {/* Comparison controls */}
+      <div className="flex items-center justify-between gap-2">
+        <label className="flex items-center gap-2 text-sm text-neutral-600 dark:text-neutral-300">
+          Compare to
+          <span className="w-36">
+            <Input
+              type="date"
+              value={pastDate}
+              max={ymdFromDate(new Date())}
+              onChange={(e) => setPastDate(e.target.value)}
+            />
+          </span>
+        </label>
+        <button
+          type="button"
+          onClick={() => setRefreshNonce((n) => n + 1)}
+          className="rounded-lg border px-2.5 py-1.5 text-sm text-neutral-600 transition hover:bg-neutral-50 dark:border-neutral-700 dark:text-neutral-300 dark:hover:bg-neutral-800"
+        >
+          ↻ Refresh
+        </button>
+      </div>
+
+      {error && (
+        <div className="text-xs text-amber-600 dark:text-amber-400">
+          {error}
+        </div>
+      )}
+
+      {/* Radar */}
+      <div className="rounded-xl border p-2 text-neutral-700 dark:border-neutral-800 dark:text-neutral-300">
+        {loading && !data ? (
+          <div className="py-16 text-center text-sm text-neutral-500 dark:text-neutral-400">
+            Loading strength standards…
+          </div>
+        ) : (
+          <ResponsiveContainer width="100%" height={300}>
+            <RadarChart data={radarData} outerRadius="72%">
+              <PolarGrid stroke="currentColor" opacity={0.2} />
+              <PolarAngleAxis
+                dataKey="axis"
+                tick={{ fontSize: 11, fill: "currentColor" }}
+              />
+              <PolarRadiusAxis
+                domain={[0, 100]}
+                tick={{ fontSize: 9, fill: "currentColor", opacity: 0.5 }}
+                axisLine={false}
+              />
+              {hasPast && (
+                <Radar
+                  name={pastDate}
+                  dataKey="past"
+                  stroke={PAST_COLOR}
+                  fill={PAST_COLOR}
+                  fillOpacity={0.15}
+                  isAnimationActive={false}
+                />
+              )}
+              <Radar
+                name="Now"
+                dataKey="now"
+                stroke={NOW_COLOR}
+                fill={NOW_COLOR}
+                fillOpacity={0.3}
+                isAnimationActive={false}
+              />
+              <Tooltip
+                formatter={(v) => (v == null ? "—" : `${Math.round(v)}%ile`)}
+              />
+              <Legend wrapperStyle={{ fontSize: 12 }} />
+            </RadarChart>
+          </ResponsiveContainer>
+        )}
+      </div>
+
+      {/* Per-axis breakdown */}
+      <div className="overflow-hidden rounded-xl border text-sm dark:border-neutral-800">
+        <div className="grid grid-cols-[1fr_auto_auto] items-center gap-2 bg-neutral-50 px-3 py-2 text-[11px] uppercase tracking-wide text-neutral-400 dark:bg-neutral-800/60">
+          <span>Lift</span>
+          <span className="text-right">Gym percentile</span>
+          <span className="text-right">Verified</span>
+        </div>
+        <div className="divide-y dark:divide-neutral-800">
+          {axesWithData.map((a) => {
+            const gym = data.now[a.key];
+            const past = data.past?.[a.key];
+            const ver = data.verified?.[a.key];
+            const tier = gym?.tier || percentileToTier(gym?.percentile);
+            const delta =
+              past?.percentile != null && gym?.percentile != null
+                ? Math.round(gym.percentile - past.percentile)
+                : null;
+            return (
+              <div
+                key={a.key}
+                className="grid grid-cols-[1fr_auto_auto] items-center gap-2 px-3 py-2"
+              >
+                <div className="min-w-0">
+                  <div className="truncate font-medium text-neutral-900 dark:text-neutral-100">
+                    {a.label}
+                  </div>
+                  <div className="mt-0.5">
+                    <TierBadge tier={tier} />
+                  </div>
+                </div>
+                <div className="text-right tabular-nums">
+                  <div className="font-semibold">
+                    {gym?.percentile != null
+                      ? `${Math.round(gym.percentile)}%`
+                      : "—"}
+                  </div>
+                  {delta != null && (
+                    <div
+                      className={`text-[11px] ${
+                        delta >= 0
+                          ? "text-emerald-600 dark:text-emerald-400"
+                          : "text-rose-600 dark:text-rose-400"
+                      }`}
+                    >
+                      {delta >= 0 ? "+" : ""}
+                      {delta} vs {pastDate}
+                    </div>
+                  )}
+                </div>
+                <div className="text-right tabular-nums text-neutral-500 dark:text-neutral-400">
+                  {ver?.percentile != null
+                    ? `${Math.round(ver.percentile)}%`
+                    : "—"}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      <p className="px-1 text-center text-[11px] text-neutral-400 dark:text-neutral-500">
+        <a
+          href={FV_ATTRIBUTION_URL}
+          target="_blank"
+          rel="noreferrer"
+          className="underline"
+        >
+          Powered by FitnessVolt Strength Standards
+        </a>
+        {" · "}
+        Gym = self-reported · Verified = OpenPowerlifting
+      </p>
+    </div>
+  );
+}

--- a/src/components/StrengthStandards.test.jsx
+++ b/src/components/StrengthStandards.test.jsx
@@ -14,8 +14,10 @@ vi.mock("recharts", async (importOriginal) => {
 });
 
 const fetchPercentiles = vi.fn();
+const fetchStandards = vi.fn();
 vi.mock("../lib/fvApi", () => ({
   fetchPercentiles: (...args) => fetchPercentiles(...args),
+  fetchStandards: (...args) => fetchStandards(...args),
   FV_ATTRIBUTION_URL: "https://fitnessvolt.com/strength-standards/",
 }));
 
@@ -40,6 +42,14 @@ beforeEach(() => {
         ? { verified: { percentile: 80, tier: "advanced" }, gym: null }
         : { gym: { percentile: 60, tier: "intermediate" }, verified: null };
     }
+    return out;
+  });
+  // LiftRatioBalance (rendered below the radar) pulls p50 standards.
+  fetchStandards.mockReset();
+  fetchStandards.mockImplementation(async (reqs) => {
+    const p50 = { squat: 110, bench: 82, deadlift: 132, ohp: 53, row: 73 };
+    const out = {};
+    for (const r of reqs) out[r.key] = { p50: p50[r.key] ?? null };
     return out;
   });
 });

--- a/src/components/StrengthStandards.test.jsx
+++ b/src/components/StrengthStandards.test.jsx
@@ -1,0 +1,108 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { beforeEach, vi } from "vitest";
+import StrengthStandards from "./StrengthStandards";
+import { saveLS, K_PROFILE, K_WEIGHT_LOGS } from "../lib/storage";
+
+const mockApp = { workouts: [] };
+vi.mock("../context/AppContext", () => ({ useApp: () => mockApp }));
+
+vi.mock("recharts", async (importOriginal) => {
+  const { withFixedResponsiveContainer } =
+    await import("../test/rechartsTestUtils");
+  return withFixedResponsiveContainer(await importOriginal());
+});
+
+const fetchPercentiles = vi.fn();
+vi.mock("../lib/fvApi", () => ({
+  fetchPercentiles: (...args) => fetchPercentiles(...args),
+  FV_ATTRIBUTION_URL: "https://fitnessvolt.com/strength-standards/",
+}));
+
+const today = new Date().toISOString().slice(0, 10);
+const workout = (date, exercises) => ({
+  id: date,
+  date,
+  name: date,
+  exercises,
+});
+const ex = (exerciseName, sets) => ({ exerciseName, sets });
+const set = (weight, reps) => ({ set: 1, weight, reps });
+
+beforeEach(() => {
+  localStorage.clear();
+  mockApp.workouts = [];
+  fetchPercentiles.mockReset();
+  fetchPercentiles.mockImplementation(async (reqs) => {
+    const out = {};
+    for (const r of reqs) {
+      out[r.key] = r.key.startsWith("ver:")
+        ? { verified: { percentile: 80, tier: "advanced" }, gym: null }
+        : { gym: { percentile: 60, tier: "intermediate" }, verified: null };
+    }
+    return out;
+  });
+});
+
+describe("StrengthStandards gating", () => {
+  it("prompts for sex when no profile is set", () => {
+    render(<StrengthStandards />);
+    expect(screen.getByText(/set your/i)).toHaveTextContent(/sex/i);
+    expect(fetchPercentiles).not.toHaveBeenCalled();
+  });
+
+  it("prompts for bodyweight when sex is set but no weight is logged", () => {
+    saveLS(K_PROFILE, { sex: "male" });
+    render(<StrengthStandards />);
+    expect(screen.getByText(/log your/i)).toHaveTextContent(/bodyweight/i);
+  });
+
+  it("prompts to log barbell lifts when there is no mappable data", () => {
+    saveLS(K_PROFILE, { sex: "male" });
+    saveLS(K_WEIGHT_LOGS, { [today]: 70 });
+    mockApp.workouts = [workout(today, [ex("Leg Press", [set(200, 5)])])];
+    render(<StrengthStandards />);
+    expect(screen.getByText(/no standard barbell lifts/i)).toBeInTheDocument();
+  });
+});
+
+describe("StrengthStandards radar", () => {
+  beforeEach(() => {
+    saveLS(K_PROFILE, { sex: "male", birthYear: 1996 });
+    saveLS(K_WEIGHT_LOGS, { [today]: 70 });
+    mockApp.workouts = [
+      workout(today, [
+        ex("Squat Barbell", [set(140, 1)]),
+        ex("Bench Press Barbell", [set(100, 1)]),
+      ]),
+    ];
+  });
+
+  it("renders the overall level, radar, and per-axis percentiles", async () => {
+    const { container } = render(<StrengthStandards />);
+    // Overall tier derived from the average gym percentile (60 -> Advanced).
+    expect(await screen.findByText("Advanced")).toBeInTheDocument();
+    // Per-axis tier badges reflect the API's own tier label.
+    expect(screen.getAllByText("Intermediate").length).toBeGreaterThan(0);
+    // Radar polygons drawn for the "Now" series.
+    expect(
+      container.querySelectorAll(".recharts-radar").length,
+    ).toBeGreaterThan(0);
+    // Axis labels + gym percentile cells.
+    expect(screen.getAllByText("Squat").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Bench").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("60%").length).toBeGreaterThan(0);
+    // Verified bonus column populated for squat/bench.
+    expect(screen.getAllByText("80%").length).toBeGreaterThan(0);
+    expect(screen.getByText(/powered by fitnessvolt/i)).toBeInTheDocument();
+  });
+
+  it("queries the API with the lifter's sex and age", async () => {
+    render(<StrengthStandards />);
+    await screen.findByText("Advanced");
+    expect(fetchPercentiles).toHaveBeenCalled();
+    const reqs = fetchPercentiles.mock.calls[0][0];
+    const squat = reqs.find((r) => r.key === "now:squat");
+    expect(squat).toMatchObject({ lift: "back_squat", sex: "male", age: 30 });
+  });
+});

--- a/src/lib/fvApi.js
+++ b/src/lib/fvApi.js
@@ -1,0 +1,94 @@
+// src/lib/fvApi.js
+// Thin client for the FitnessVolt Strength Standards API
+// (https://fitnessvolt.com/strength-standards/developers/). Free, no auth,
+// CORS-enabled. This is the app's only network dependency, so every call is
+// cached in localStorage and failures degrade gracefully — the rest of the app
+// stays offline-first.
+//
+// Attribution ("Powered by FitnessVolt Strength Standards") is required by the
+// free tier and rendered in the Symmetry view.
+
+import { loadLS, saveLS, K_FV_CACHE } from "./storage";
+
+export const FV_BASE = "https://fitnessvolt.com/wp-json/fvss/v1";
+export const FV_ATTRIBUTION_URL = "https://fitnessvolt.com/strength-standards/";
+
+// Round to 0.5 kg so trivially different maxes/bodyweights share a cache entry
+// and we don't hammer the rate-limited API (60 req/min per IP per endpoint).
+const round = (n) => Math.round((Number(n) || 0) * 2) / 2;
+
+/** Stable cache key for one percentile lookup. */
+export function buildCacheKey({ lift, weight, bodyweight, sex, age, unit }) {
+  return [
+    lift,
+    sex,
+    age || "all",
+    unit || "kg",
+    round(weight),
+    round(bodyweight),
+  ].join("|");
+}
+
+function readCache() {
+  const c = loadLS(K_FV_CACHE, {});
+  return c && typeof c === "object" ? c : {};
+}
+
+/**
+ * Look up the dual (verified + gym) percentile for one lift. Results are cached;
+ * pass `{ cache: false }` to force a fresh request (still writes the cache).
+ *
+ * @returns {Promise<{ verified: object|null, gym: object|null }>}
+ */
+export async function fetchPercentile(
+  { lift, weight, bodyweight, sex, age, unit = "kg" },
+  { fetchImpl = fetch, cache = true } = {},
+) {
+  const key = buildCacheKey({ lift, weight, bodyweight, sex, age, unit });
+  if (cache) {
+    const hit = readCache()[key];
+    if (hit) return hit;
+  }
+
+  const body = { lift, weight, bodyweight, sex, reps: 1, unit };
+  if (age) body.age = age;
+
+  const res = await fetchImpl(`${FV_BASE}/percentile`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    throw new Error(`FitnessVolt API ${res.status}`);
+  }
+  const json = await res.json();
+  const result = { verified: json.verified || null, gym: json.gym || null };
+
+  const all = readCache();
+  all[key] = result;
+  saveLS(K_FV_CACHE, all);
+  return result;
+}
+
+/**
+ * Resolve several percentile lookups sequentially (gentle on the rate limit).
+ * Individual failures are isolated: a rejected lookup yields `{ error }` for
+ * that request rather than failing the whole batch.
+ *
+ * @param {Array} requests - each `{ key, ...fetchPercentile args }`. `key`
+ *   identifies the result in the returned map (defaults to `lift`).
+ * @returns {Promise<Object>} map of request key -> result or `{ error: string }`.
+ */
+export async function fetchPercentiles(requests, opts = {}) {
+  const out = {};
+  for (const req of requests || []) {
+    const { key, ...args } = req;
+    const id = key ?? args.lift;
+    try {
+      out[id] = await fetchPercentile(args, opts);
+    } catch (e) {
+      out[id] = { error: e?.message || "request failed" };
+    }
+  }
+  return out;
+}

--- a/src/lib/fvApi.js
+++ b/src/lib/fvApi.js
@@ -92,3 +92,94 @@ export async function fetchPercentiles(requests, opts = {}) {
   }
   return out;
 }
+
+/** Stable cache key for one standards (percentile-table) lookup. */
+export function buildStandardsCacheKey({
+  lift,
+  bodyweight,
+  sex,
+  age,
+  source,
+  unit,
+}) {
+  return [
+    "std",
+    lift,
+    sex,
+    source || "gym",
+    age || "all",
+    unit || "kg",
+    round(bodyweight),
+  ].join("|");
+}
+
+/**
+ * Look up the percentile *table* for one lift at a bodyweight — notably `p50`,
+ * the median lift, which we use to derive empirical "average" strength ratios.
+ * Cached alongside percentile lookups (distinct `std|…` key namespace).
+ *
+ * @returns {Promise<{ percentiles: object, p50: number|null, bwMultiple: number|null }>}
+ */
+export async function fetchStandard(
+  { lift, bodyweight, sex, age, source = "gym", unit = "kg" },
+  { fetchImpl = fetch, cache = true } = {},
+) {
+  const key = buildStandardsCacheKey({
+    lift,
+    bodyweight,
+    sex,
+    age,
+    source,
+    unit,
+  });
+  if (cache) {
+    const hit = readCache()[key];
+    if (hit) return hit;
+  }
+
+  const params = new URLSearchParams({
+    bodyweight: String(bodyweight),
+    sex,
+    unit,
+    source,
+  });
+  if (age) params.set("age", String(age));
+
+  const res = await fetchImpl(`${FV_BASE}/standards/${lift}?${params}`);
+  if (!res.ok) {
+    throw new Error(`FitnessVolt API ${res.status}`);
+  }
+  const json = await res.json();
+  const percentiles = json.percentiles || {};
+  const result = {
+    percentiles,
+    p50: percentiles.p50 ?? null,
+    bwMultiple: json.p50_bw_multiple ?? null,
+  };
+
+  const all = readCache();
+  all[key] = result;
+  saveLS(K_FV_CACHE, all);
+  return result;
+}
+
+/**
+ * Resolve several standards lookups sequentially, isolating failures the same
+ * way `fetchPercentiles` does.
+ *
+ * @param {Array} requests - each `{ key, ...fetchStandard args }`.
+ * @returns {Promise<Object>} map of request key -> result or `{ error: string }`.
+ */
+export async function fetchStandards(requests, opts = {}) {
+  const out = {};
+  for (const req of requests || []) {
+    const { key, ...args } = req;
+    const id = key ?? args.lift;
+    try {
+      out[id] = await fetchStandard(args, opts);
+    } catch (e) {
+      out[id] = { error: e?.message || "request failed" };
+    }
+  }
+  return out;
+}

--- a/src/lib/fvApi.test.js
+++ b/src/lib/fvApi.test.js
@@ -1,5 +1,12 @@
 import { beforeEach, vi } from "vitest";
-import { buildCacheKey, fetchPercentile, fetchPercentiles } from "./fvApi";
+import {
+  buildCacheKey,
+  fetchPercentile,
+  fetchPercentiles,
+  buildStandardsCacheKey,
+  fetchStandard,
+  fetchStandards,
+} from "./fvApi";
 import { K_FV_CACHE } from "./storage";
 
 beforeEach(() => {
@@ -111,6 +118,74 @@ describe("fetchPercentiles", () => {
       { fetchImpl },
     );
     expect(res.squat.gym.percentile).toBe(60);
+    expect(res.bench.error).toMatch(/network down/);
+  });
+});
+
+describe("buildStandardsCacheKey", () => {
+  it("namespaces under 'std' and includes the source", () => {
+    const k = buildStandardsCacheKey({
+      lift: "back_squat",
+      bodyweight: 70,
+      sex: "male",
+      source: "gym",
+    });
+    expect(k.startsWith("std|")).toBe(true);
+    expect(k).toContain("gym");
+  });
+});
+
+describe("fetchStandard", () => {
+  it("GETs the lift standards and surfaces p50", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(
+        ok({ percentiles: { p50: 110.5 }, p50_bw_multiple: 1.49 }),
+      );
+    const res = await fetchStandard(
+      { lift: "back_squat", bodyweight: 70, sex: "male", source: "gym" },
+      { fetchImpl },
+    );
+    expect(res.p50).toBe(110.5);
+    expect(res.bwMultiple).toBe(1.49);
+    const [url, init] = fetchImpl.mock.calls[0];
+    expect(url).toMatch(/\/standards\/back_squat\?/);
+    expect(url).toContain("source=gym");
+    // standards is a GET — no method/body.
+    expect(init).toBeUndefined();
+  });
+
+  it("caches under the std namespace and serves the second call from cache", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(ok({ percentiles: { p50: 82.3 } }));
+    const args = {
+      lift: "bench_press",
+      bodyweight: 70,
+      sex: "male",
+      source: "gym",
+    };
+    await fetchStandard(args, { fetchImpl });
+    await fetchStandard(args, { fetchImpl });
+    expect(fetchImpl).toHaveBeenCalledOnce();
+    expect(loadCache()["std|bench_press|male|gym|all|kg|70"]).toBeTruthy();
+  });
+});
+
+describe("fetchStandards", () => {
+  it("resolves a batch keyed by request key and isolates failures", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(ok({ percentiles: { p50: 110 } }))
+      .mockRejectedValueOnce(new Error("network down"));
+    const res = await fetchStandards(
+      [
+        { key: "squat", lift: "back_squat", bodyweight: 70, sex: "male" },
+        { key: "bench", lift: "bench_press", bodyweight: 70, sex: "male" },
+      ],
+      { fetchImpl },
+    );
+    expect(res.squat.p50).toBe(110);
     expect(res.bench.error).toMatch(/network down/);
   });
 });

--- a/src/lib/fvApi.test.js
+++ b/src/lib/fvApi.test.js
@@ -1,0 +1,120 @@
+import { beforeEach, vi } from "vitest";
+import { buildCacheKey, fetchPercentile, fetchPercentiles } from "./fvApi";
+import { K_FV_CACHE } from "./storage";
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+const ok = (json) => ({ ok: true, status: 200, json: async () => json });
+
+describe("buildCacheKey", () => {
+  it("rounds weight/bodyweight to 0.5 kg so near-identical maxes share a key", () => {
+    const base = { lift: "deadlift", sex: "male", unit: "kg", age: 30 };
+    expect(buildCacheKey({ ...base, weight: 120.1, bodyweight: 70.2 })).toBe(
+      buildCacheKey({ ...base, weight: 120.0, bodyweight: 70.0 }),
+    );
+  });
+
+  it("treats missing age as the 'all' cohort", () => {
+    expect(
+      buildCacheKey({
+        lift: "squat",
+        sex: "male",
+        weight: 100,
+        bodyweight: 70,
+      }),
+    ).toContain("all");
+  });
+});
+
+describe("fetchPercentile", () => {
+  it("POSTs the lift and returns the dual percentile", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      ok({
+        verified: { percentile: 75, tier: "advanced" },
+        gym: { percentile: 68, tier: "intermediate" },
+      }),
+    );
+    const res = await fetchPercentile(
+      { lift: "deadlift", weight: 150, bodyweight: 70, sex: "male", age: 30 },
+      { fetchImpl },
+    );
+    expect(res.gym.tier).toBe("intermediate");
+    expect(fetchImpl).toHaveBeenCalledOnce();
+    const [url, init] = fetchImpl.mock.calls[0];
+    expect(url).toMatch(/\/percentile$/);
+    const body = JSON.parse(init.body);
+    expect(body).toMatchObject({
+      lift: "deadlift",
+      weight: 150,
+      reps: 1,
+      age: 30,
+    });
+  });
+
+  it("serves a cached result without a second request", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(ok({ gym: { percentile: 50 } }));
+    const args = { lift: "squat", weight: 100, bodyweight: 70, sex: "male" };
+    await fetchPercentile(args, { fetchImpl });
+    await fetchPercentile(args, { fetchImpl });
+    expect(fetchImpl).toHaveBeenCalledOnce();
+    expect(loadCache()["squat|male|all|kg|100|70"]).toBeTruthy();
+  });
+
+  it("bypasses the cache when cache:false but still records it", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(ok({ gym: { percentile: 50 } }));
+    const args = { lift: "squat", weight: 100, bodyweight: 70, sex: "male" };
+    await fetchPercentile(args, { fetchImpl, cache: true });
+    await fetchPercentile(args, { fetchImpl, cache: false });
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws on a non-ok response", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({ ok: false, status: 429 });
+    await expect(
+      fetchPercentile(
+        { lift: "squat", weight: 100, bodyweight: 70, sex: "male" },
+        { fetchImpl },
+      ),
+    ).rejects.toThrow(/429/);
+  });
+});
+
+describe("fetchPercentiles", () => {
+  it("resolves a batch and isolates individual failures", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(ok({ gym: { percentile: 60 } }))
+      .mockRejectedValueOnce(new Error("network down"));
+    const res = await fetchPercentiles(
+      [
+        {
+          key: "squat",
+          lift: "back_squat",
+          weight: 140,
+          bodyweight: 70,
+          sex: "male",
+        },
+        {
+          key: "bench",
+          lift: "bench_press",
+          weight: 100,
+          bodyweight: 70,
+          sex: "male",
+        },
+      ],
+      { fetchImpl },
+    );
+    expect(res.squat.gym.percentile).toBe(60);
+    expect(res.bench.error).toMatch(/network down/);
+  });
+});
+
+function loadCache() {
+  return JSON.parse(localStorage.getItem(K_FV_CACHE) || "{}");
+}

--- a/src/lib/liftRatios.js
+++ b/src/lib/liftRatios.js
@@ -1,0 +1,107 @@
+// src/lib/liftRatios.js
+// Pure helpers for the Progress -> Symmetry "Lift Balance" panel, a take on
+// FitnessVolt's Strength Symmetry Analyzer: it compares the *ratios* between
+// your main barbell lifts to the ratios of the median lifter.
+//
+// The key idea: instead of inventing "ideal" ratio constants, the benchmark
+// ratios are derived from the API's own p50 (median) standards at your
+// bodyweight/sex. So "average" means a real median lifter, not a guess.
+//
+// All weights are kg. Network access lives in fvApi.js (fetchStandards).
+
+// Squat is the reference lift; every ratio is <lift> : squat.
+export const RATIO_BASE = "squat";
+export const RATIO_BASE_LABEL = "Squat";
+
+// The big barbell lifts we compare. `slug` is the FitnessVolt standards slug,
+// which also matches the gym slug keys produced by bestE1RMBySlug.
+export const RATIO_LIFTS = [
+  { key: "squat", label: "Squat", slug: "back_squat" },
+  { key: "bench", label: "Bench Press", slug: "bench_press" },
+  { key: "deadlift", label: "Deadlift", slug: "deadlift" },
+  { key: "ohp", label: "Overhead Press", slug: "overhead_press" },
+  { key: "row", label: "Barbell Row", slug: "pendlay_row" },
+];
+
+// Within this fraction of the median ratio counts as "balanced".
+export const RATIO_TOLERANCE = 0.05;
+
+const num = (v) => (Number.isFinite(Number(v)) ? Number(v) : null);
+
+/**
+ * Build one comparison row per non-base lift that has both a user value and a
+ * median value (and a usable squat base in each). Each row carries the user's
+ * lift:squat ratio, the median lift:squat ratio, the fractional difference, and
+ * a balanced/weak/strong assessment.
+ *
+ * @param {Object<string,number>} userByKey - lift key -> user e1RM (kg).
+ * @param {Object<string,number>} avgByKey  - lift key -> median (p50) lift (kg).
+ * @returns {Array<{key,label,userRatio,avgRatio,diff,assessment}>}
+ */
+export function buildRatioRows(userByKey, avgByKey, tol = RATIO_TOLERANCE) {
+  const uBase = num(userByKey?.[RATIO_BASE]);
+  const aBase = num(avgByKey?.[RATIO_BASE]);
+  if (!uBase || !aBase) return [];
+
+  const rows = [];
+  for (const lift of RATIO_LIFTS) {
+    if (lift.key === RATIO_BASE) continue;
+    const u = num(userByKey?.[lift.key]);
+    const a = num(avgByKey?.[lift.key]);
+    if (u == null || a == null || a <= 0) continue;
+
+    const userRatio = u / uBase;
+    const avgRatio = a / aBase;
+    const diff = userRatio / avgRatio - 1; // fractional vs median
+    let assessment = "balanced";
+    if (diff > tol) assessment = "strong";
+    else if (diff < -tol) assessment = "weak";
+
+    rows.push({
+      key: lift.key,
+      label: lift.label,
+      userRatio,
+      avgRatio,
+      diff,
+      assessment,
+    });
+  }
+  return rows;
+}
+
+/**
+ * Overall symmetry score (0-100). Each lift earns full credit when its ratio
+ * matches the median and zero credit once it deviates by half (50%); the score
+ * is the average credit. Null when there are no rows to score.
+ */
+export function overallScore(rows) {
+  if (!rows || rows.length === 0) return null;
+  const credit = rows.reduce(
+    (sum, r) => sum + Math.max(0, 1 - Math.abs(r.diff) / 0.5),
+    0,
+  );
+  return Math.round((credit / rows.length) * 100);
+}
+
+/** Word label for an overall score. */
+export function scoreRating(score) {
+  if (score == null) return null;
+  if (score >= 90) return "Excellent";
+  if (score >= 75) return "Good";
+  if (score >= 60) return "Fair";
+  return "Imbalanced";
+}
+
+/**
+ * The most-lagging and most-leading lifts, for a "focus here" callout.
+ * Returns nulls when nothing is meaningfully out of balance.
+ */
+export function focusAreas(rows, tol = RATIO_TOLERANCE) {
+  const weak = rows
+    .filter((r) => r.diff < -tol)
+    .sort((a, b) => a.diff - b.diff)[0];
+  const strong = rows
+    .filter((r) => r.diff > tol)
+    .sort((a, b) => b.diff - a.diff)[0];
+  return { weakest: weak || null, strongest: strong || null };
+}

--- a/src/lib/liftRatios.test.js
+++ b/src/lib/liftRatios.test.js
@@ -1,0 +1,88 @@
+import {
+  buildRatioRows,
+  overallScore,
+  scoreRating,
+  focusAreas,
+} from "./liftRatios";
+
+// Median (p50) lifts roughly matching a male @70kg: squat 110, bench 82,
+// deadlift 132, ohp 53, row 73. Median ratios: bench .745, dl 1.2, ohp .48, row .66.
+const avg = { squat: 110, bench: 82, deadlift: 132, ohp: 53, row: 73 };
+
+describe("buildRatioRows", () => {
+  it("returns one row per non-base lift present in both user and average", () => {
+    const user = { squat: 100, bench: 75, deadlift: 120 };
+    const rows = buildRatioRows(user, avg);
+    expect(rows.map((r) => r.key).sort()).toEqual(["bench", "deadlift"]);
+    expect(rows.find((r) => r.key === "bench")).toMatchObject({
+      label: "Bench Press",
+    });
+  });
+
+  it("returns nothing when the squat base is missing on either side", () => {
+    expect(buildRatioRows({ bench: 75 }, avg)).toEqual([]);
+    expect(buildRatioRows({ squat: 100, bench: 75 }, { bench: 82 })).toEqual(
+      [],
+    );
+  });
+
+  it("flags a lift matching the median ratio as balanced", () => {
+    // bench/squat = 82/110 = median exactly.
+    const rows = buildRatioRows({ squat: 110, bench: 82 }, avg);
+    expect(rows[0].assessment).toBe("balanced");
+    expect(Math.abs(rows[0].diff)).toBeLessThan(1e-9);
+  });
+
+  it("flags a lift far above its median ratio as strong, below as weak", () => {
+    // Same squat as median; bench way over -> strong, deadlift way under -> weak.
+    const rows = buildRatioRows({ squat: 110, bench: 110, deadlift: 100 }, avg);
+    expect(rows.find((r) => r.key === "bench").assessment).toBe("strong");
+    expect(rows.find((r) => r.key === "deadlift").assessment).toBe("weak");
+  });
+});
+
+describe("overallScore / scoreRating", () => {
+  it("scores a perfectly proportioned lifter at 100 (Excellent)", () => {
+    const rows = buildRatioRows(
+      { squat: 220, bench: 164, deadlift: 264, ohp: 106, row: 146 },
+      avg,
+    );
+    const s = overallScore(rows);
+    expect(s).toBe(100);
+    expect(scoreRating(s)).toBe("Excellent");
+  });
+
+  it("drops the score as ratios drift from the median", () => {
+    const rows = buildRatioRows({ squat: 110, bench: 110 }, avg); // bench +48%
+    expect(overallScore(rows)).toBeLessThan(100);
+  });
+
+  it("returns null for an empty set", () => {
+    expect(overallScore([])).toBeNull();
+    expect(scoreRating(null)).toBeNull();
+  });
+
+  it("maps score bands to words", () => {
+    expect(scoreRating(95)).toBe("Excellent");
+    expect(scoreRating(80)).toBe("Good");
+    expect(scoreRating(65)).toBe("Fair");
+    expect(scoreRating(40)).toBe("Imbalanced");
+  });
+});
+
+describe("focusAreas", () => {
+  it("names the most-lagging and most-leading lifts", () => {
+    const rows = buildRatioRows(
+      { squat: 110, bench: 110, deadlift: 100, ohp: 53 },
+      avg,
+    );
+    const { weakest, strongest } = focusAreas(rows);
+    expect(strongest.key).toBe("bench");
+    expect(weakest.key).toBe("deadlift");
+  });
+
+  it("returns nulls when everything is balanced", () => {
+    const rows = buildRatioRows({ squat: 220, bench: 164, deadlift: 264 }, avg);
+    expect(focusAreas(rows)).toEqual({ weakest: null, strongest: null });
+  });
+});

--- a/src/lib/storage.js
+++ b/src/lib/storage.js
@@ -17,6 +17,10 @@ export const K_THEME = "mgym.theme";
 export const K_SESSION = "mgym.session.v1";
 /** localStorage key for body-weight logs ({ "YYYY-MM-DD": number }). Predates the "mgym" prefix. */
 export const K_WEIGHT_LOGS = "weightLogs";
+/** localStorage key for the lifter profile ({ sex, birthYear }) used by strength standards. */
+export const K_PROFILE = "mgym.profile.v1";
+/** localStorage key for the FitnessVolt strength-standards response cache. */
+export const K_FV_CACHE = "mgym.fvCache.v1";
 
 /** Today's date as a `YYYY-MM-DD` string (UTC-sliced). */
 export const todayStr = () => new Date().toISOString().slice(0, 10);

--- a/src/lib/strengthStandards.js
+++ b/src/lib/strengthStandards.js
@@ -23,10 +23,19 @@ export const EXERCISE_SLUG_MAP = {
   deadlift: "deadlift",
   "sumo deadlift": "sumo_deadlift",
   "shoulder press barbell": "overhead_press",
+  "shoulder press": "overhead_press",
+  "overhead press": "overhead_press",
   "pull-up": "pullup",
   "pull-up (wide grip)": "pullup",
+  "pull up": "pullup",
+  "pull ups": "pullup",
+  pullup: "pullup",
+  pullups: "pullup",
   "chin-ups": "chinup",
+  "chin up": "chinup",
+  "chin ups": "chinup",
   "bent-over row barbell": "pendlay_row",
+  "barbell row": "pendlay_row",
 };
 
 // Slugs scored relative to total system weight (bodyweight + any added load)

--- a/src/lib/strengthStandards.js
+++ b/src/lib/strengthStandards.js
@@ -1,0 +1,175 @@
+// src/lib/strengthStandards.js
+// Pure helpers for the Progress -> Symmetry view, which scores your lifts against
+// the FitnessVolt Strength Standards API (https://fitnessvolt.com/strength-standards).
+//
+// The API only publishes standards for a fixed set of barbell / bodyweight lifts,
+// so the radar is movement-based: one axis per lift group the API supports. Each
+// axis is fed by the best estimated 1RM (kg) among the exercises that map to it.
+//
+// All weights are kg (the storage invariant). The network layer lives in fvApi.js;
+// this module is framework- and fetch-free so it stays trivially testable.
+
+import { estimate1RM } from "./strength";
+import { setReps } from "./metrics";
+
+// Lowercased exercise name -> FitnessVolt "gym" (Symmetric Strength) lift slug.
+// Only barbell / bodyweight lifts with a clean, unambiguous standard are mapped;
+// dumbbell and machine variants are intentionally left out (different standards).
+export const EXERCISE_SLUG_MAP = {
+  "squat barbell": "back_squat",
+  "back squat": "back_squat",
+  "front squat": "front_squat",
+  "bench press barbell": "bench_press",
+  deadlift: "deadlift",
+  "sumo deadlift": "sumo_deadlift",
+  "shoulder press barbell": "overhead_press",
+  "pull-up": "pullup",
+  "pull-up (wide grip)": "pullup",
+  "chin-ups": "chinup",
+  "bent-over row barbell": "pendlay_row",
+};
+
+// Slugs scored relative to total system weight (bodyweight + any added load)
+// rather than the bare bar weight.
+export const BODYWEIGHT_SLUGS = new Set(["pullup", "chinup", "dip"]);
+
+// Radar axes. Each axis aggregates one or more gym slugs (best percentile wins).
+// `verified` is the OpenPowerlifting slug shown as a bonus stat where one exists
+// (squat / bench-press / deadlift only); it is scored from the first axis slug.
+export const RADAR_AXES = [
+  {
+    key: "squat",
+    label: "Squat",
+    slugs: ["back_squat", "front_squat"],
+    verified: "squat",
+  },
+  {
+    key: "bench",
+    label: "Bench",
+    slugs: ["bench_press"],
+    verified: "bench-press",
+  },
+  {
+    key: "deadlift",
+    label: "Deadlift",
+    slugs: ["deadlift", "sumo_deadlift"],
+    verified: "deadlift",
+  },
+  { key: "ohp", label: "Overhead Press", slugs: ["overhead_press"] },
+  { key: "pull", label: "Pull-up", slugs: ["pullup", "chinup"] },
+  { key: "row", label: "Row", slugs: ["pendlay_row"] },
+];
+
+// Strength tiers, weakest to strongest, matching the API's `tier` values.
+export const TIERS = [
+  "beginner",
+  "novice",
+  "intermediate",
+  "advanced",
+  "elite",
+];
+
+/** Map an exercise name to its gym lift slug, or undefined when unsupported. */
+export function slugForExercise(name) {
+  return EXERCISE_SLUG_MAP[(name || "").toLowerCase().trim()];
+}
+
+/**
+ * Best estimated 1RM (kg) per gym slug across workouts, optionally capped at a
+ * date (inclusive) so a past milestone can be reconstructed.
+ *
+ * For bodyweight slugs the value is the best *added* load (which may be 0 — a set
+ * of unweighted pull-ups still counts); callers add bodyweight via `liftWeight`.
+ * For loaded slugs, zero-weight sets are ignored.
+ *
+ * @returns {Object<string, number>} slug -> best e1RM in kg.
+ */
+export function bestE1RMBySlug(workouts, asOf = null) {
+  const out = {};
+  for (const w of workouts || []) {
+    const date = w?.date;
+    if (!date) continue;
+    if (asOf && date > asOf) continue;
+    for (const ex of w.exercises || []) {
+      const slug = slugForExercise(ex.exerciseName);
+      if (!slug) continue;
+      const bw = BODYWEIGHT_SLUGS.has(slug);
+      for (const s of ex.sets || []) {
+        const reps = setReps(s);
+        if (reps <= 0) continue;
+        const wt = Number(s.weight) || 0;
+        if (!bw && wt <= 0) continue;
+        const e = estimate1RM(wt, reps);
+        if (!(slug in out) || e > out[slug]) out[slug] = e;
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * The weight to score for a slug: total system weight for bodyweight lifts
+ * (bodyweight + added e1RM), otherwise the bare e1RM.
+ */
+export function liftWeight(slug, e1rm, bodyweight) {
+  const added = Number(e1rm) || 0;
+  return BODYWEIGHT_SLUGS.has(slug) ? (Number(bodyweight) || 0) + added : added;
+}
+
+/** Current age in whole years from a birth year, or null when unknown. */
+export function ageFromBirthYear(birthYear, now = new Date()) {
+  const y = Number(birthYear);
+  if (!Number.isFinite(y) || y < 1900) return null;
+  const age = now.getFullYear() - y;
+  return age >= 10 && age <= 90 ? age : null;
+}
+
+/** Map a percentile (0-100) to a strength tier; null passes through. */
+export function percentileToTier(p) {
+  if (p == null || !Number.isFinite(Number(p))) return null;
+  const v = Number(p);
+  if (v < 20) return "beginner";
+  if (v < 40) return "novice";
+  if (v < 60) return "intermediate";
+  if (v < 80) return "advanced";
+  return "elite";
+}
+
+/** Average percentile across axes mapped to an overall tier; null when empty. */
+export function overallTier(percentiles) {
+  const vals = (percentiles || []).filter(
+    (p) => p != null && Number.isFinite(Number(p)),
+  );
+  if (vals.length === 0) return null;
+  const avg = vals.reduce((a, b) => a + Number(b), 0) / vals.length;
+  return percentileToTier(avg);
+}
+
+/** Star rating (0-5) from an average percentile, for a strengthlevel-style header. */
+export function starsFromPercentile(p) {
+  if (p == null || !Number.isFinite(Number(p))) return 0;
+  return Math.max(0, Math.min(5, Math.round((Number(p) / 100) * 5)));
+}
+
+/**
+ * Resolve, per axis, which slug to query and at what weight, for one snapshot
+ * (a set of slug e1RMs + a bodyweight). Axes with no logged data are dropped.
+ *
+ * @returns {Array<{ axis, slug, e1rm, weight }>} one entry per axis with data,
+ *   where `slug` is the best-available slug for that axis and `weight` is the
+ *   value to send to the percentile endpoint.
+ */
+export function axisRequests(e1rmBySlug, bodyweight) {
+  const reqs = [];
+  for (const axis of RADAR_AXES) {
+    let best = null;
+    for (const slug of axis.slugs) {
+      if (!(slug in (e1rmBySlug || {}))) continue;
+      const e1rm = e1rmBySlug[slug];
+      const weight = liftWeight(slug, e1rm, bodyweight);
+      if (!best || weight > best.weight) best = { slug, e1rm, weight };
+    }
+    if (best) reqs.push({ axis: axis.key, ...best });
+  }
+  return reqs;
+}

--- a/src/lib/strengthStandards.test.js
+++ b/src/lib/strengthStandards.test.js
@@ -26,6 +26,15 @@ describe("slugForExercise", () => {
     expect(slugForExercise("Chin-ups")).toBe("chinup");
   });
 
+  it("maps spelling/spacing variants of common lifts", () => {
+    // "Pull up" (space) must map the same as "Pull-up" (hyphen).
+    expect(slugForExercise("Pull up")).toBe("pullup");
+    expect(slugForExercise("Pull-up")).toBe("pullup");
+    expect(slugForExercise("Pullups")).toBe("pullup");
+    expect(slugForExercise("Shoulder press")).toBe("overhead_press");
+    expect(slugForExercise("Barbell Row")).toBe("pendlay_row");
+  });
+
   it("returns undefined for unsupported or empty names", () => {
     expect(slugForExercise("Leg Press")).toBeUndefined();
     expect(slugForExercise("")).toBeUndefined();

--- a/src/lib/strengthStandards.test.js
+++ b/src/lib/strengthStandards.test.js
@@ -1,0 +1,151 @@
+import {
+  slugForExercise,
+  bestE1RMBySlug,
+  liftWeight,
+  ageFromBirthYear,
+  percentileToTier,
+  overallTier,
+  starsFromPercentile,
+  axisRequests,
+  BODYWEIGHT_SLUGS,
+} from "./strengthStandards";
+
+const workout = (date, exercises) => ({
+  id: date,
+  date,
+  name: date,
+  exercises,
+});
+const ex = (exerciseName, sets) => ({ exerciseName, sets });
+const set = (weight, reps) => ({ set: 1, weight, reps });
+
+describe("slugForExercise", () => {
+  it("maps known names case-insensitively, trimming whitespace", () => {
+    expect(slugForExercise("Squat Barbell")).toBe("back_squat");
+    expect(slugForExercise("  bench press barbell ")).toBe("bench_press");
+    expect(slugForExercise("Chin-ups")).toBe("chinup");
+  });
+
+  it("returns undefined for unsupported or empty names", () => {
+    expect(slugForExercise("Leg Press")).toBeUndefined();
+    expect(slugForExercise("")).toBeUndefined();
+    expect(slugForExercise(undefined)).toBeUndefined();
+  });
+});
+
+describe("bestE1RMBySlug", () => {
+  it("takes the best estimated 1RM per slug across workouts", () => {
+    const wos = [
+      workout("2026-01-01", [ex("Deadlift", [set(100, 5)])]), // ~116.67
+      workout("2026-02-01", [ex("Deadlift", [set(120, 1)])]), // 120
+    ];
+    expect(bestE1RMBySlug(wos).deadlift).toBeCloseTo(120, 5);
+  });
+
+  it("collapses variants of an axis onto their own slugs", () => {
+    const wos = [
+      workout("2026-01-01", [
+        ex("Squat Barbell", [set(140, 1)]),
+        ex("Front Squat", [set(100, 1)]),
+      ]),
+    ];
+    const m = bestE1RMBySlug(wos);
+    expect(m.back_squat).toBeCloseTo(140, 5);
+    expect(m.front_squat).toBeCloseTo(100, 5);
+  });
+
+  it("caps at an as-of date (inclusive)", () => {
+    const wos = [
+      workout("2026-01-01", [ex("Deadlift", [set(100, 1)])]),
+      workout("2026-06-01", [ex("Deadlift", [set(150, 1)])]),
+    ];
+    expect(bestE1RMBySlug(wos, "2026-03-01").deadlift).toBeCloseTo(100, 5);
+    expect(bestE1RMBySlug(wos, "2026-06-01").deadlift).toBeCloseTo(150, 5);
+  });
+
+  it("ignores zero-weight sets for loaded lifts but keeps them for bodyweight", () => {
+    const loaded = [workout("2026-01-01", [ex("Deadlift", [set(0, 10)])])];
+    expect(bestE1RMBySlug(loaded).deadlift).toBeUndefined();
+
+    const bw = [workout("2026-01-01", [ex("Pull-up", [set(0, 8)])])];
+    expect(bestE1RMBySlug(bw).pullup).toBe(0);
+  });
+
+  it("ignores sets with no reps and unmapped exercises", () => {
+    const wos = [
+      workout("2026-01-01", [
+        ex("Deadlift", [set(100, 0)]),
+        ex("Leg Press", [set(200, 5)]),
+      ]),
+    ];
+    expect(bestE1RMBySlug(wos)).toEqual({});
+  });
+});
+
+describe("liftWeight", () => {
+  it("adds bodyweight for bodyweight slugs and passes through otherwise", () => {
+    expect(BODYWEIGHT_SLUGS.has("pullup")).toBe(true);
+    expect(liftWeight("pullup", 10, 70)).toBe(80);
+    expect(liftWeight("pullup", 0, 70)).toBe(70);
+    expect(liftWeight("back_squat", 140, 70)).toBe(140);
+  });
+});
+
+describe("ageFromBirthYear", () => {
+  const now = new Date("2026-06-15");
+  it("computes age within the API's 10-90 range", () => {
+    expect(ageFromBirthYear(1996, now)).toBe(30);
+  });
+  it("returns null for missing or out-of-range years", () => {
+    expect(ageFromBirthYear(undefined, now)).toBeNull();
+    expect(ageFromBirthYear(2020, now)).toBeNull(); // age 6
+    expect(ageFromBirthYear(1800, now)).toBeNull();
+  });
+});
+
+describe("percentileToTier / overallTier", () => {
+  it("buckets percentiles into tiers", () => {
+    expect(percentileToTier(5)).toBe("beginner");
+    expect(percentileToTier(30)).toBe("novice");
+    expect(percentileToTier(50)).toBe("intermediate");
+    expect(percentileToTier(75)).toBe("advanced");
+    expect(percentileToTier(95)).toBe("elite");
+    expect(percentileToTier(null)).toBeNull();
+  });
+
+  it("averages axis percentiles for an overall tier", () => {
+    expect(overallTier([50, 70])).toBe("advanced"); // avg 60
+    expect(overallTier([])).toBeNull();
+    expect(overallTier([null, 50])).toBe("intermediate"); // ignores null
+  });
+});
+
+describe("starsFromPercentile", () => {
+  it("scales a percentile to 0-5 stars", () => {
+    expect(starsFromPercentile(0)).toBe(0);
+    expect(starsFromPercentile(50)).toBe(3); // 2.5 -> 3
+    expect(starsFromPercentile(100)).toBe(5);
+    expect(starsFromPercentile(null)).toBe(0);
+  });
+});
+
+describe("axisRequests", () => {
+  it("picks the heaviest slug per axis and drops axes with no data", () => {
+    const reqs = axisRequests(
+      { back_squat: 140, front_squat: 120, bench_press: 100 },
+      70,
+    );
+    const squat = reqs.find((r) => r.axis === "squat");
+    const bench = reqs.find((r) => r.axis === "bench");
+    expect(squat).toMatchObject({ slug: "back_squat", weight: 140 });
+    expect(bench).toMatchObject({ slug: "bench_press", weight: 100 });
+    expect(reqs.find((r) => r.axis === "deadlift")).toBeUndefined();
+  });
+
+  it("scores bodyweight axes against total system weight", () => {
+    const reqs = axisRequests({ pullup: 10, chinup: 5 }, 70);
+    const pull = reqs.find((r) => r.axis === "pull");
+    // pullup: 70+10=80 beats chinup: 70+5=75
+    expect(pull).toMatchObject({ slug: "pullup", weight: 80 });
+  });
+});


### PR DESCRIPTION
## Summary
- New Progress → Symmetry view: a strengthlevel.com-style radar comparing your best logged lifts against the FitnessVolt Strength Standards API, with an overall tier/star rating and a now-vs-past-date comparison.
- Movement-based axes (Squat, Bench, Deadlift, Overhead Press, Pull-up, Row) map logged exercises to the API's gym lift slugs; verified (OpenPowerlifting) percentiles shown as a bonus for squat/bench/deadlift. Bodyweight lifts (pull-up/chin-up/dip) score against total system weight.
- New Profile section in More (sex, birth year) used only to query the API; stored locally only.
- New `src/lib/fvApi.js` network client with a localStorage cache (`mgym.fvCache.v1`, 0.5kg-bucketed keys) — this is the app's only network dependency and degrades gracefully offline.
- Pure helpers in `src/lib/strengthStandards.js` (slug mapping, best-e1RM aggregation, tiers/stars, axis request building) with full unit test coverage.
- Docs updated: `ARCHITECTURE.md` and `docs/DATA-MODEL.md`.

## Test plan
- [x] `npm run check` passes (lint, format, tests, build)
- [x] Verified live in browser against the real FitnessVolt API with seeded localStorage data — radar, tiers, percentiles, past-date deltas, and verified bonus column all render correctly
- [x] Verified new More → Profile section renders and persists sex/birth year

🤖 Generated with [Claude Code](https://claude.com/claude-code)