### PR TITLE
Add per-lift source mapping + bar-weight config to Symmetry

### DIFF
--- a/docs/DATA-MODEL.md
+++ b/docs/DATA-MODEL.md
@@ -175,10 +175,29 @@ Optional self-reported data the **Progress → Symmetry** view needs to score
 lifts against the FitnessVolt Strength Standards API. Authored in **More →
 Profile**, self-persisted (not part of the backup payload, not in `AppContext`).
 
-| Field       | Type                   | Purpose                                          |
-| ----------- | ---------------------- | ------------------------------------------------ |
-| `sex`       | `"male"` \| `"female"` | Required by the standards API; absent until set. |
-| `birthYear` | `number` (optional)    | Sharpens the gym age cohort; omitted when blank. |
+| Field        | Type                   | Purpose                                          |
+| ------------ | ---------------------- | ------------------------------------------------ |
+| `sex`        | `"male"` \| `"female"` | Required by the standards API; absent until set. |
+| `birthYear`  | `number` (optional)    | Sharpens the gym age cohort; omitted when blank. |
+| `liftConfig` | `LiftConfig` (opt.)    | Per-lift source mapping + bar-weight adjustment. |
+
+#### LiftConfig
+
+Optional overrides authored in **More → Profile → Lift sources**, keyed by
+standard-lift key (`squat`, `bench`, `deadlift`, `ohp`, `pull`, `row` — the
+`RADAR_AXES` keys). Each value tunes how that lift's data is pulled for the
+Symmetry view; absent keys fall back to automatic detection from the exercise
+name.
+
+| Field      | Type      | Purpose                                                               |
+| ---------- | --------- | --------------------------------------------------------------------- |
+| `exercise` | `string`  | Pins which logged exercise feeds the lift (overrides the alias map).  |
+| `addBar`   | `boolean` | When true, adds `barKg` to every set's weight **before** the 1RM est. |
+| `barKg`    | `number`  | Bar weight to add when `addBar`; defaults to 20 kg.                   |
+
+The offset is applied per set inside `bestE1RMBySlug` (so it flows into both the
+radar and the Lift Balance panel). See `src/lib/strengthStandards.js`
+(`buildLiftConfigIndex`).
 
 ### Strength-standards cache (`mgym.fvCache.v1`)
 

--- a/src/components/LiftSourcesEditor.jsx
+++ b/src/components/LiftSourcesEditor.jsx
@@ -1,0 +1,109 @@
+// src/components/LiftSourcesEditor.jsx
+// More → Profile → "Lift sources": maps each of the standard Symmetry lifts to
+// the exercise it should pull data from, and lets you add the bar weight for
+// lifts you log plates-only. Both are optional per lift — leave a row untouched
+// and the Symmetry view keeps auto-detecting from the exercise name.
+
+import React, { useMemo } from "react";
+import { STANDARD_LIFTS, DEFAULT_BAR_KG } from "../lib/strengthStandards";
+import Combobox from "./ui/Combobox";
+import { Input } from "./ui/Input";
+
+/**
+ * Controlled editor for `profile.liftConfig`.
+ *
+ * @param {Object} value - the current liftConfig ({ [liftKey]: { exercise, addBar, barKg } }).
+ * @param {(next: Object) => void} onChange - called with the next liftConfig.
+ * @param {string[]} exerciseNames - names to offer in each exercise picker.
+ */
+export default function LiftSourcesEditor({
+  value,
+  onChange,
+  exerciseNames = [],
+}) {
+  const config = value || {};
+  const options = useMemo(
+    () => [...exerciseNames].sort((a, b) => a.localeCompare(b)),
+    [exerciseNames],
+  );
+
+  const setLift = (key, patch) => {
+    const next = { ...config };
+    const entry = { ...(next[key] || {}), ...patch };
+    // Drop a row that carries no real config so the stored object stays small.
+    if (!entry.exercise && !entry.addBar) delete next[key];
+    else next[key] = entry;
+    onChange(next);
+  };
+
+  return (
+    <div className="space-y-3">
+      <p className="px-1 text-[12px] leading-snug text-neutral-500 dark:text-neutral-400">
+        Pick which exercise feeds each lift, and tick{" "}
+        <span className="font-medium">Add bar</span> for lifts you log without
+        the bar (the bar weight is added to every set before scoring). Untouched
+        lifts are detected automatically from the exercise name.
+      </p>
+
+      <div className="space-y-2">
+        {STANDARD_LIFTS.map((lift) => {
+          const c = config[lift.key] || {};
+          const addBar = Boolean(c.addBar);
+          return (
+            <div
+              key={lift.key}
+              className="rounded-xl border p-3 dark:border-neutral-800"
+            >
+              <div className="mb-2 text-sm font-medium text-neutral-900 dark:text-neutral-100">
+                {lift.label}
+              </div>
+
+              <Combobox
+                value={c.exercise || ""}
+                onChange={(exercise) =>
+                  setLift(lift.key, { exercise: exercise || undefined })
+                }
+                options={options}
+                placeholder="Auto (detect from name)"
+              />
+
+              <label className="mt-2 flex items-center gap-2 text-sm text-neutral-700 dark:text-neutral-300">
+                <input
+                  type="checkbox"
+                  className="h-4 w-4 rounded border-neutral-300 dark:border-neutral-600"
+                  checked={addBar}
+                  onChange={(e) =>
+                    setLift(lift.key, { addBar: e.target.checked })
+                  }
+                />
+                <span>Add bar weight</span>
+                {addBar && (
+                  <span className="ml-auto flex items-center gap-1">
+                    <span className="w-16">
+                      <Input
+                        type="number"
+                        inputMode="decimal"
+                        min="0"
+                        step="0.5"
+                        value={c.barKg ?? DEFAULT_BAR_KG}
+                        onChange={(e) => {
+                          const v = e.target.value.trim();
+                          setLift(lift.key, {
+                            barKg: v === "" ? DEFAULT_BAR_KG : Number(v),
+                          });
+                        }}
+                      />
+                    </span>
+                    <span className="text-neutral-500 dark:text-neutral-400">
+                      kg
+                    </span>
+                  </span>
+                )}
+              </label>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/LiftSourcesEditor.test.jsx
+++ b/src/components/LiftSourcesEditor.test.jsx
@@ -1,0 +1,68 @@
+import React, { useState } from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import LiftSourcesEditor from "./LiftSourcesEditor";
+
+const NAMES = ["Bench Press Barbell", "Deadlift", "My Squat"];
+
+// Controlled wrapper so onChange round-trips into the rendered value.
+function Harness({ initial = {} }) {
+  const [value, setValue] = useState(initial);
+  return (
+    <LiftSourcesEditor
+      value={value}
+      onChange={setValue}
+      exerciseNames={NAMES}
+    />
+  );
+}
+
+describe("LiftSourcesEditor", () => {
+  it("renders a row for every standard lift", () => {
+    render(<Harness />);
+    for (const label of [
+      "Squat",
+      "Bench",
+      "Deadlift",
+      "Overhead Press",
+      "Pull-up",
+      "Row",
+    ]) {
+      expect(screen.getByText(label)).toBeInTheDocument();
+    }
+  });
+
+  it("checking Add bar reveals the kg input defaulted to 20", async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    const boxes = screen.getAllByRole("checkbox");
+    expect(screen.queryByDisplayValue("20")).not.toBeInTheDocument();
+    await user.click(boxes[0]); // Squat row
+    expect(screen.getByDisplayValue("20")).toBeInTheDocument();
+  });
+
+  it("prunes a row back out once its bar is unchecked and exercise cleared", async () => {
+    const onChange = vi.fn();
+    render(
+      <LiftSourcesEditor
+        value={{ bench: { addBar: true, barKg: 20 } }}
+        onChange={onChange}
+        exerciseNames={NAMES}
+      />,
+    );
+    // The bench row's checkbox is the 2nd one and starts checked.
+    const boxes = screen.getAllByRole("checkbox");
+    expect(boxes[1]).toBeChecked();
+    await userEvent.setup().click(boxes[1]);
+    expect(onChange).toHaveBeenCalledWith({});
+  });
+
+  it("pins an exercise via the picker", async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    // First combobox is the Squat row.
+    const combos = screen.getAllByRole("combobox");
+    await user.type(combos[0], "My Squat");
+    expect(combos[0]).toHaveValue("My Squat");
+  });
+});

--- a/src/components/MoreMenu.jsx
+++ b/src/components/MoreMenu.jsx
@@ -1,9 +1,10 @@
-import React, { useState } from "react";
+import React, { useMemo, useState } from "react";
 import { useApp } from "../context/AppContext";
 import Segmented from "./ui/Segmented";
 import { Input } from "./ui/Input";
 import Notepad from "./Notepad";
 import DataManagementMenu from "./DataManagementMenu";
+import LiftSourcesEditor from "./LiftSourcesEditor";
 import { loadLS, saveLS, K_PROFILE } from "../lib/storage";
 
 /**
@@ -21,8 +22,27 @@ function SectionLabel({ children }) {
 }
 
 export default function MoreMenu() {
-  const { theme, setTheme } = useApp();
+  const { theme, setTheme, workouts, exercises } = useApp();
   const [view, setView] = useState("menu");
+
+  // Every exercise name the user could map a standard lift to: those they've
+  // logged plus the rest of their exercise database, deduped case-insensitively.
+  const exerciseNames = useMemo(() => {
+    const seen = new Set();
+    const out = [];
+    const add = (name) => {
+      const n = (name || "").trim();
+      if (!n) return;
+      const k = n.toLowerCase();
+      if (seen.has(k)) return;
+      seen.add(k);
+      out.push(n);
+    };
+    for (const w of workouts || [])
+      for (const ex of w.exercises || []) add(ex.exerciseName);
+    for (const ex of exercises || []) add(ex.name);
+    return out;
+  }, [workouts, exercises]);
 
   // Lifter profile (sex + birth year) for the Progress -> Symmetry view's
   // strength-standards lookups. Self-persisted like the Notepad/Weight logs.
@@ -46,6 +66,28 @@ export default function MoreMenu() {
           <span aria-hidden>←</span> More
         </button>
         <Notepad />
+      </div>
+    );
+  }
+
+  if (view === "liftSources") {
+    return (
+      <div className="space-y-3">
+        <button
+          type="button"
+          onClick={() => setView("menu")}
+          className="flex items-center gap-1 text-sm text-blue-600 dark:text-blue-400"
+        >
+          <span aria-hidden>←</span> More
+        </button>
+        <h1 className="px-1 text-xl font-semibold text-neutral-900 dark:text-neutral-100">
+          Lift sources
+        </h1>
+        <LiftSourcesEditor
+          value={profile.liftConfig}
+          onChange={(liftConfig) => updateProfile({ liftConfig })}
+          exerciseNames={exerciseNames}
+        />
       </div>
     );
   }
@@ -127,6 +169,24 @@ export default function MoreMenu() {
               />
             </div>
           </div>
+          <button
+            type="button"
+            onClick={() => setView("liftSources")}
+            className="flex w-full items-center justify-between px-3 py-3 text-left transition hover:bg-neutral-50 dark:hover:bg-neutral-800"
+          >
+            <div>
+              <div className={rowText}>Lift sources</div>
+              <div className="text-[11px] text-neutral-500 dark:text-neutral-400">
+                Map lifts to exercises · add bar weight
+              </div>
+            </div>
+            <span
+              aria-hidden
+              className="text-neutral-400 dark:text-neutral-500"
+            >
+              ›
+            </span>
+          </button>
         </div>
         <p className="mt-1 px-1 text-[11px] text-neutral-400 dark:text-neutral-500">
           Used only to compare your lifts against strength standards. Stays on

--- a/src/components/StrengthStandards.jsx
+++ b/src/components/StrengthStandards.jsx
@@ -86,6 +86,7 @@ export default function StrengthStandards() {
   const weightLogs = useMemo(() => loadLS(K_WEIGHT_LOGS, {}), []);
   const sex = profile.sex;
   const age = ageFromBirthYear(profile.birthYear);
+  const liftConfig = profile.liftConfig;
 
   // Default the comparison date to ~6 months ago.
   const defaultPast = useMemo(() => {
@@ -100,11 +101,15 @@ export default function StrengthStandards() {
   const bwPast = bodyweightAsOf(weightLogs, pastDate) ?? bwNow;
 
   // Best current e1RM per slug — feeds both the radar and the lift-balance panel.
-  const e1rmNow = useMemo(() => bestE1RMBySlug(wos), [wos]);
+  // liftConfig pins exercise→lift mappings and adds bar weight where logged out.
+  const e1rmNow = useMemo(
+    () => bestE1RMBySlug(wos, null, liftConfig),
+    [wos, liftConfig],
+  );
 
   // Build the per-axis lookup requests for both snapshots.
   const { nowReqs, pastReqs, verifiedReqs } = useMemo(() => {
-    const e1rmPast = bestE1RMBySlug(wos, pastDate);
+    const e1rmPast = bestE1RMBySlug(wos, pastDate, liftConfig);
     const now = axisRequests(e1rmNow, bwNow);
     const past = axisRequests(e1rmPast, bwPast);
     // Verified bonus: only squat/bench/deadlift, scored from each axis's
@@ -122,7 +127,7 @@ export default function StrengthStandards() {
       });
     }
     return { nowReqs: now, pastReqs: past, verifiedReqs: verified };
-  }, [wos, e1rmNow, pastDate, bwNow, bwPast]);
+  }, [wos, e1rmNow, pastDate, bwNow, bwPast, liftConfig]);
 
   const [state, setState] = useState({
     loading: false,

--- a/src/lib/strengthStandards.js
+++ b/src/lib/strengthStandards.js
@@ -69,6 +69,17 @@ export const RADAR_AXES = [
   { key: "row", label: "Row", slugs: ["pendlay_row"] },
 ];
 
+// The standard lifts the Symmetry view scores, in display order. Derived from
+// RADAR_AXES so the keys/labels never drift. `slug` is the canonical FitnessVolt
+// slug a manual source mapping feeds; `slugs` are every slug the axis aggregates
+// (a manual mapping claims all of them so an auto match can't double up).
+export const STANDARD_LIFTS = RADAR_AXES.map((a) => ({
+  key: a.key,
+  label: a.label,
+  slug: a.slugs[0],
+  slugs: a.slugs,
+}));
+
 // Strength tiers, weakest to strongest, matching the API's `tier` values.
 export const TIERS = [
   "beginner",
@@ -84,6 +95,46 @@ export function slugForExercise(name) {
 }
 
 /**
+ * Per-lift source overrides authored in More → Profile (`profile.liftConfig`).
+ * One entry per standard lift key:
+ *   { exercise?: string, addBar?: boolean, barKg?: number }
+ * `exercise` pins which logged exercise feeds the lift (overriding the alias
+ * auto-detection); `addBar` adds `barKg` (default 20) to every set's logged
+ * weight *before* the 1RM estimate, for lifts logged without the bar.
+ *
+ * Returns fast lookups for `bestE1RMBySlug`:
+ *   - overrideByExercise: lowercased exercise name -> { slug, offset }
+ *   - claimedSlugs: slugs owned by an explicit exercise pick (auto matches skip)
+ *   - offsetBySlug: slug -> offset for "add bar" set without an explicit pick
+ */
+export const DEFAULT_BAR_KG = 20;
+
+export function buildLiftConfigIndex(config) {
+  const overrideByExercise = {};
+  const claimedSlugs = new Set();
+  const offsetBySlug = {};
+  if (!config) return { overrideByExercise, claimedSlugs, offsetBySlug };
+
+  for (const lift of STANDARD_LIFTS) {
+    const c = config[lift.key];
+    if (!c) continue;
+    const offset = c.addBar
+      ? Number.isFinite(Number(c.barKg))
+        ? Number(c.barKg)
+        : DEFAULT_BAR_KG
+      : 0;
+    const exName = (c.exercise || "").toLowerCase().trim();
+    if (exName) {
+      overrideByExercise[exName] = { slug: lift.slug, offset };
+      for (const slug of lift.slugs) claimedSlugs.add(slug);
+    } else if (offset) {
+      for (const slug of lift.slugs) offsetBySlug[slug] = offset;
+    }
+  }
+  return { overrideByExercise, claimedSlugs, offsetBySlug };
+}
+
+/**
  * Best estimated 1RM (kg) per gym slug across workouts, optionally capped at a
  * date (inclusive) so a past milestone can be reconstructed.
  *
@@ -91,24 +142,40 @@ export function slugForExercise(name) {
  * of unweighted pull-ups still counts); callers add bodyweight via `liftWeight`.
  * For loaded slugs, zero-weight sets are ignored.
  *
+ * An optional `config` (`profile.liftConfig`) pins exercise→lift mappings and
+ * adds the bar weight for lifts logged plates-only — applied per set before the
+ * 1RM estimate (see `buildLiftConfigIndex`).
+ *
  * @returns {Object<string, number>} slug -> best e1RM in kg.
  */
-export function bestE1RMBySlug(workouts, asOf = null) {
+export function bestE1RMBySlug(workouts, asOf = null, config = null) {
+  const { overrideByExercise, claimedSlugs, offsetBySlug } =
+    buildLiftConfigIndex(config);
   const out = {};
   for (const w of workouts || []) {
     const date = w?.date;
     if (!date) continue;
     if (asOf && date > asOf) continue;
     for (const ex of w.exercises || []) {
-      const slug = slugForExercise(ex.exerciseName);
-      if (!slug) continue;
+      const name = (ex.exerciseName || "").toLowerCase().trim();
+      const ov = overrideByExercise[name];
+      let slug, offset;
+      if (ov) {
+        slug = ov.slug;
+        offset = ov.offset;
+      } else {
+        slug = slugForExercise(ex.exerciseName);
+        // A slug pinned to a specific exercise is fed only by that exercise.
+        if (!slug || claimedSlugs.has(slug)) continue;
+        offset = offsetBySlug[slug] || 0;
+      }
       const bw = BODYWEIGHT_SLUGS.has(slug);
       for (const s of ex.sets || []) {
         const reps = setReps(s);
         if (reps <= 0) continue;
         const wt = Number(s.weight) || 0;
         if (!bw && wt <= 0) continue;
-        const e = estimate1RM(wt, reps);
+        const e = estimate1RM(wt + offset, reps);
         if (!(slug in out) || e > out[slug]) out[slug] = e;
       }
     }

--- a/src/lib/strengthStandards.test.js
+++ b/src/lib/strengthStandards.test.js
@@ -1,6 +1,7 @@
 import {
   slugForExercise,
   bestE1RMBySlug,
+  buildLiftConfigIndex,
   liftWeight,
   ageFromBirthYear,
   percentileToTier,
@@ -8,6 +9,7 @@ import {
   starsFromPercentile,
   axisRequests,
   BODYWEIGHT_SLUGS,
+  STANDARD_LIFTS,
 } from "./strengthStandards";
 
 const workout = (date, exercises) => ({
@@ -88,6 +90,92 @@ describe("bestE1RMBySlug", () => {
       ]),
     ];
     expect(bestE1RMBySlug(wos)).toEqual({});
+  });
+});
+
+describe("STANDARD_LIFTS", () => {
+  it("exposes the six axes with a single canonical slug each", () => {
+    expect(STANDARD_LIFTS.map((l) => l.key)).toEqual([
+      "squat",
+      "bench",
+      "deadlift",
+      "ohp",
+      "pull",
+      "row",
+    ]);
+    const squat = STANDARD_LIFTS.find((l) => l.key === "squat");
+    expect(squat.slug).toBe("back_squat");
+    expect(squat.slugs).toContain("front_squat");
+  });
+});
+
+describe("buildLiftConfigIndex", () => {
+  it("returns empty lookups for no config", () => {
+    const idx = buildLiftConfigIndex(null);
+    expect(idx.overrideByExercise).toEqual({});
+    expect(idx.claimedSlugs.size).toBe(0);
+    expect(idx.offsetBySlug).toEqual({});
+  });
+
+  it("pins an exercise to a slug and claims all of the axis's slugs", () => {
+    const idx = buildLiftConfigIndex({
+      squat: { exercise: "My Squat", addBar: true, barKg: 20 },
+    });
+    expect(idx.overrideByExercise["my squat"]).toEqual({
+      slug: "back_squat",
+      offset: 20,
+    });
+    expect(idx.claimedSlugs.has("back_squat")).toBe(true);
+    expect(idx.claimedSlugs.has("front_squat")).toBe(true);
+  });
+
+  it("applies an offset to the axis slugs when no exercise is pinned", () => {
+    const idx = buildLiftConfigIndex({ bench: { addBar: true, barKg: 15 } });
+    expect(idx.offsetBySlug.bench_press).toBe(15);
+    expect(idx.overrideByExercise).toEqual({});
+  });
+
+  it("defaults a checked bar with no kg to 20 and ignores an unchecked bar", () => {
+    const idx = buildLiftConfigIndex({
+      bench: { addBar: true },
+      deadlift: { exercise: "DL", addBar: false, barKg: 20 },
+    });
+    expect(idx.offsetBySlug.bench_press).toBe(20);
+    expect(idx.overrideByExercise.dl.offset).toBe(0);
+  });
+});
+
+describe("bestE1RMBySlug with liftConfig", () => {
+  it("adds the bar weight to every set before the 1RM estimate", () => {
+    const wos = [workout("2026-01-01", [ex("Bench", [set(60, 5)])])];
+    // Pinned to "Bench" + add 20kg bar -> (60+20) * (1 + 5/30) = 93.33
+    const cfg = { bench: { exercise: "Bench", addBar: true, barKg: 20 } };
+    expect(bestE1RMBySlug(wos, null, cfg).bench_press).toBeCloseTo(93.33, 1);
+  });
+
+  it("pins a slug to its chosen exercise, dropping auto matches for it", () => {
+    const wos = [
+      workout("2026-01-01", [
+        ex("My Bench", [set(100, 1)]),
+        ex("Bench Press Barbell", [set(80, 1)]), // would auto-map to bench_press
+      ]),
+    ];
+    const cfg = { bench: { exercise: "My Bench" } };
+    // Only the pinned exercise feeds bench_press; the auto match is suppressed.
+    expect(bestE1RMBySlug(wos, null, cfg).bench_press).toBeCloseTo(100, 5);
+  });
+
+  it("leaves untouched lifts on auto-detection", () => {
+    const wos = [
+      workout("2026-01-01", [
+        ex("Deadlift", [set(100, 1)]),
+        ex("Bench", [set(60, 5)]),
+      ]),
+    ];
+    const cfg = { bench: { exercise: "Bench", addBar: true, barKg: 20 } };
+    const m = bestE1RMBySlug(wos, null, cfg);
+    expect(m.deadlift).toBeCloseTo(100, 5); // auto, no offset
+    expect(m.bench_press).toBeCloseTo(93.33, 1); // configured
   });
 });
 


### PR DESCRIPTION
## Problem

Two things broke the Progress → Symmetry comparison against FitnessVolt:

1. **Bar weight.** Some lifts are logged plates-only (no bar), so a 60 kg log is really 80 kg — the comparison undercounts those lifts.
2. **Name mismatch.** Exercises whose names don't match the built-in alias map (e.g. plain "Squat"/"Bench") were silently dropped from the radar and Lift Balance.

The user didn't want to change how they log, so this adds configuration instead.

## What this adds

A new **More → Profile → Lift sources** screen with one row per standard lift (Squat, Bench, Deadlift, Overhead Press, Pull-up, Row). Each row is optional:

- **Source exercise** — pin which logged exercise feeds the lift (a searchable `Combobox`), overriding the alias auto-detection. A pinned exercise *owns* its lift's slugs, so an auto match can't double up.
- **Add bar weight** — checkbox + editable kg (default 20). The offset is added to **every set before the Epley 1RM estimate** (not after — that would be ~5 kg off), for lifts logged without the bar.

Untouched lifts keep the current automatic detection, so this is fully backward-compatible.

## Implementation

- Stored under `profile.liftConfig` (`mgym.profile.v1`), keyed by standard-lift key.
- Applied centrally in `bestE1RMBySlug` via the new `buildLiftConfigIndex` helper, so **both** the radar and the Lift Balance panel honor it from one place.
- `STANDARD_LIFTS` derived from `RADAR_AXES` to avoid drift.

## Tests & verification

- New unit tests for `buildLiftConfigIndex`, `STANDARD_LIFTS`, and config-aware `bestE1RMBySlug` (bar offset before Epley, slug pinning, untouched-lift fallthrough).
- New RTL tests for `LiftSourcesEditor` (rows render, Add-bar reveals kg input, row pruning, exercise pinning).
- `npm run check` green (268 tests, lint/format clean, build ok).
- Verified live in the browser: pinning "Squat"/"Bench"/"Deadlift" surfaces all three on the radar; Bench's +20 kg flows through (shows 71% of squat, vs 53% without it); Lift Balance computes; no console errors.

## Docs

- `docs/DATA-MODEL.md` documents the `LiftConfig` shape under the lifter profile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
