### PR TITLE
Show running rep total for the current exercise in live logging

### DIFF
--- a/src/components/LiveSession.jsx
+++ b/src/components/LiveSession.jsx
@@ -7,6 +7,7 @@ import {
   isLogged,
   completedSets,
   totalSets,
+  exerciseReps,
   formatClock,
   remapIndexAfterMove,
   restRemaining,
@@ -90,6 +91,7 @@ export default function LiveSession() {
     Math.max(0, exs.length - 1),
   );
   const current = exs[currentIdx] || null;
+  const currentReps = exerciseReps(current);
   const elapsed = Math.floor((nowTs - (session.startedAt || nowTs)) / 1000);
 
   // --- mutations (write through to the persisted workout) ---
@@ -319,6 +321,11 @@ export default function LiveSession() {
                 >
                   {current.exerciseName}
                 </button>
+              </div>
+              <div className="mb-3 -mt-2 text-xs text-neutral-500 dark:text-neutral-400">
+                {currentReps} {currentReps === 1 ? "rep" : "reps"} so far
+              </div>
+              <div className="mb-3 flex items-center justify-end gap-1">
                 <div className="flex shrink-0 items-center gap-1">
                   {exs.length > 1 && (
                     <>

--- a/src/components/LiveSession.test.jsx
+++ b/src/components/LiveSession.test.jsx
@@ -56,6 +56,22 @@ describe("LiveSession", () => {
     expect(screen.getByText(/1\/1 sets/)).toBeInTheDocument();
   });
 
+  it("shows the running rep total for the current exercise", async () => {
+    const user = userEvent.setup();
+    seedAndRender();
+    // The seeded set already has 8 reps logged.
+    expect(screen.getByText("8 reps so far")).toBeInTheDocument();
+
+    // Add a set and log it; the total should grow.
+    await user.click(screen.getByRole("button", { name: /Add set/i }));
+    const repsInputs = screen.getAllByRole("spinbutton");
+    const newRepsInput = repsInputs[repsInputs.length - 1];
+    await user.clear(newRepsInput);
+    await user.type(newRepsInput, "5");
+
+    expect(screen.getByText("13 reps so far")).toBeInTheDocument();
+  });
+
   it("an added set starts unlogged until reps are entered", async () => {
     const user = userEvent.setup();
     seedAndRender();

--- a/src/lib/liveSession.js
+++ b/src/lib/liveSession.js
@@ -23,6 +23,13 @@ export function completedSets(workout) {
   return n;
 }
 
+/** Total reps logged across a single exercise's sets. */
+export function exerciseReps(exercise) {
+  let n = 0;
+  for (const s of exercise?.sets || []) n += Number(s?.reps) || 0;
+  return n;
+}
+
 /**
  * New index of an exercise originally at `index` after moving the exercise at
  * `from` to `to` (matching arrayUtils.moveItem semantics). Used to keep the

--- a/src/lib/liveSession.test.js
+++ b/src/lib/liveSession.test.js
@@ -2,6 +2,7 @@ import {
   isLogged,
   totalSets,
   completedSets,
+  exerciseReps,
   remapIndexAfterMove,
   formatClock,
   restRemaining,
@@ -23,6 +24,21 @@ describe("isLogged / completedSets", () => {
       ],
     };
     expect(completedSets(workout)).toBe(2);
+  });
+});
+
+describe("exerciseReps", () => {
+  it("sums reps across an exercise's sets", () => {
+    expect(exerciseReps({ sets: [{ reps: 8 }, { reps: 6 }] })).toBe(14);
+  });
+
+  it("treats unlogged (reps: 0) sets as contributing nothing", () => {
+    expect(exerciseReps({ sets: [{ reps: 8 }, { reps: 0 }] })).toBe(8);
+  });
+
+  it("is zero for an empty/absent exercise", () => {
+    expect(exerciseReps({ sets: [] })).toBe(0);
+    expect(exerciseReps(null)).toBe(0);
   });
 });
 


### PR DESCRIPTION
## Summary
- Adds `exerciseReps(exercise)` to `src/lib/liveSession.js`, summing `reps` across an exercise's sets.
- Displays "N reps so far" under the exercise name on the current-exercise card in live logging, updating instantly as sets are logged (reps entered).

## Why
While logging a workout live, lifters can now see their running rep total for the current exercise as they complete sets, without needing to do the math themselves.

## Test plan
- [x] Added unit tests for `exerciseReps` (sums reps, ignores unlogged `reps: 0` sets, handles empty/null exercise).
- [x] Added a component test verifying the total renders and increments when a new set's reps are entered.
- [x] `npm run check` passes (lint, format, 272 tests, build).
- [x] Verified visually in preview — "14 reps so far" rendered for two seeded sets (8 + 6 reps).