### PR TITLE
Add reusable routine templates

### DIFF
--- a/src/components/CalendarView.jsx
+++ b/src/components/CalendarView.jsx
@@ -10,9 +10,17 @@ import { Plus, Trash2 } from "./ui/Icons";
 import { useConfirm } from "./ConfirmDialog";
 import { createExerciseEntry } from "../lib/exerciseUtils";
 import { useApp } from "../context/AppContext";
+import RoutinePicker from "./RoutinePicker";
 
 export default function CalendarView() {
-  const { workouts, setWorkouts, exercises, setExercises, unit } = useApp();
+  const {
+    workouts,
+    setWorkouts,
+    exercises,
+    setExercises,
+    unit,
+    addWorkoutFromRoutine,
+  } = useApp();
   const [viewDate, setViewDate] = useState(
     () => new Date(new Date().getFullYear(), new Date().getMonth(), 1),
   );
@@ -114,9 +122,13 @@ export default function CalendarView() {
           <div className="flex items-center justify-between mb-2">
             <div className="font-semibold">Plans for {selected}</div>
             <Button variant="primary" onClick={createWorkoutForSelected}>
-              <Plus /> New workout
+              <Plus /> New
             </Button>
           </div>
+          <RoutinePicker
+            label="From routine"
+            onPick={(routine) => addWorkoutFromRoutine(routine.id, selected)}
+          />
           {selectedWorkouts.length === 0 && (
             <p className="text-sm text-neutral-500 dark:text-neutral-400">
               No workouts on this day.

--- a/src/components/DataManagementMenu.jsx
+++ b/src/components/DataManagementMenu.jsx
@@ -14,6 +14,7 @@ import {
   normalizeData,
   mergeExercises,
   mergeWorkouts,
+  mergeRoutines,
 } from "../lib/backup";
 import { useApp } from "../context/AppContext";
 
@@ -24,7 +25,14 @@ import { useApp } from "../context/AppContext";
  * or import data in either merge or replace mode.
  */
 export default function DataManagementMenu() {
-  const { exercises, workouts, setExercises, setWorkouts } = useApp();
+  const {
+    exercises,
+    workouts,
+    routines,
+    setExercises,
+    setWorkouts,
+    setRoutines,
+  } = useApp();
   const [open, setOpen] = useState(false);
   const fileRef = useRef(null);
   const modeRef = useRef("merge");
@@ -51,6 +59,7 @@ export default function DataManagementMenu() {
       exportedAt: new Date().toISOString(),
       exercises,
       workouts,
+      routines,
       unit: unitPref,
       tab: tabPref,
       note,
@@ -76,14 +85,20 @@ export default function DataManagementMenu() {
     reader.onload = () => {
       try {
         const raw = JSON.parse(reader.result);
-        // sanitize exercises and workouts using normalizeData
-        const { exercises: inEx, workouts: inWo } = normalizeData(raw);
+        // sanitize exercises, workouts, and routines using normalizeData
+        const {
+          exercises: inEx,
+          workouts: inWo,
+          routines: inRo,
+        } = normalizeData(raw);
         if (modeRef.current === "replace") {
           setExercises(inEx);
           setWorkouts(inWo);
+          setRoutines(inRo);
         } else {
           setExercises((prev) => mergeExercises(prev, inEx));
           setWorkouts((prev) => mergeWorkouts(prev, inWo));
+          setRoutines((prev) => mergeRoutines(prev, inRo));
         }
         // restore additional fields if present
         if (raw.unit != null) saveLS(K_UNIT, raw.unit);

--- a/src/components/LiveSession.jsx
+++ b/src/components/LiveSession.jsx
@@ -37,6 +37,7 @@ export default function LiveSession() {
     setExercises,
     unit,
     endSession,
+    saveRoutineFromWorkout,
   } = useApp();
 
   const workout = workouts.find((w) => w.id === session?.workoutId) || null;
@@ -262,6 +263,22 @@ export default function LiveSession() {
               {formatClock(elapsed)} elapsed · {completed}/{total} sets
             </div>
           </div>
+          <button
+            type="button"
+            onClick={() => {
+              if (exs.length > 0) saveRoutineFromWorkout(workout);
+              confirm({
+                title: "Saved as routine",
+                message: `"${workout.name || "Workout"}" added to your routines.`,
+                confirmText: "OK",
+                tone: "neutral",
+              });
+            }}
+            disabled={exs.length === 0}
+            className="rounded-xl border px-3 py-2 text-sm font-medium text-neutral-600 transition hover:bg-neutral-50 disabled:opacity-40 dark:border-neutral-700 dark:text-neutral-300 dark:hover:bg-neutral-800"
+          >
+            Save as routine
+          </button>
           <button
             type="button"
             onClick={finish}

--- a/src/components/RoutineEditor.jsx
+++ b/src/components/RoutineEditor.jsx
@@ -1,0 +1,148 @@
+import React, { useState } from "react";
+import { Button } from "./ui/Button";
+import { Input } from "./ui/Input";
+import AddExerciseInput from "./AddExerciseInput";
+import WorkoutExerciseEditor from "./WorkoutExerciseEditor";
+import { useApp } from "../context/AppContext";
+import { useConfirm } from "./ConfirmDialog";
+import { createExerciseEntry } from "../lib/exerciseUtils";
+import { moveItem } from "../lib/arrayUtils";
+import { normalizeRpe, normalizeFeedback } from "../lib/rpe";
+import { MAX_SETS } from "../lib/constants";
+import { uuid } from "../lib/storage";
+
+/**
+ * Create or edit a Routine. No date field — routines are dateless templates.
+ * Props:
+ *   routine   – existing routine to edit (null for new)
+ *   onSave    – called with the saved routine object
+ *   onCancel  – called when user cancels
+ */
+export default function RoutineEditor({ routine = null, onSave, onCancel }) {
+  const { exercises, setExercises, unit } = useApp();
+  const confirm = useConfirm();
+
+  const [name, setName] = useState(routine?.name ?? "");
+  const [items, setItems] = useState(
+    routine?.exercises
+      ? routine.exercises.map((we) => ({
+          ...we,
+          sets: we.sets.map((s) => ({ ...s })),
+        }))
+      : [],
+  );
+
+  const addExerciseByName = (rawName) => {
+    const entry = createExerciseEntry(rawName, exercises, setExercises);
+    if (!entry) return;
+    if (
+      !items.some(
+        (i) =>
+          i.exerciseName.toLowerCase() === entry.exerciseName.toLowerCase(),
+      )
+    ) {
+      setItems((prev) => [...prev, entry]);
+    }
+  };
+
+  const moveUp = (idx) => setItems((prev) => moveItem(prev, idx, idx - 1));
+  const moveDown = (idx) => setItems((prev) => moveItem(prev, idx, idx + 1));
+
+  const handleSave = () => {
+    if (!name.trim() || items.length === 0) return;
+    const now = Date.now();
+    const saved = {
+      id: routine?.id ?? uuid(),
+      name: name.trim(),
+      exercises: items.map((i) => ({
+        exerciseName: i.exerciseName.trim(),
+        sets: i.sets.slice(0, MAX_SETS).map((s, idx) => ({
+          set: idx + 1,
+          weight: Number(s.weight) || 0,
+          reps: Number(s.reps) || 0,
+        })),
+        rpe: normalizeRpe(i.rpe),
+        feedback: normalizeFeedback(i.feedback),
+      })),
+      createdAt: routine?.createdAt ?? now,
+      updatedAt: now,
+    };
+    onSave(saved);
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-1">
+        <label className="text-xs text-neutral-600 dark:text-neutral-300">
+          Routine name
+        </label>
+        <Input
+          placeholder="e.g. Push Day A"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+        />
+      </div>
+
+      <div className="space-y-2">
+        {items.length === 0 && (
+          <p className="text-sm text-neutral-500 dark:text-neutral-400">
+            No exercises added yet.
+          </p>
+        )}
+        {items.map((it, idx) => {
+          const rec =
+            exercises.find((e) => e.name === it.exerciseName)?.recommendRep ||
+            "";
+          return (
+            <WorkoutExerciseEditor
+              key={it.exerciseName}
+              item={it}
+              unit={unit}
+              recommendRep={rec}
+              onChange={(patch) =>
+                setItems((prev) =>
+                  prev.map((x) =>
+                    x.exerciseName === it.exerciseName ? { ...x, ...patch } : x,
+                  ),
+                )
+              }
+              onRemove={() => {
+                confirm({
+                  title: `Remove "${it.exerciseName}"?`,
+                  message: "This removes it from the routine.",
+                  confirmText: "Remove",
+                  tone: "destructive",
+                }).then((ok) => {
+                  if (ok)
+                    setItems((prev) =>
+                      prev.filter((x) => x.exerciseName !== it.exerciseName),
+                    );
+                });
+              }}
+              onMoveUp={() => moveUp(idx)}
+              onMoveDown={() => moveDown(idx)}
+              canMoveUp={idx > 0}
+              canMoveDown={idx < items.length - 1}
+              onShowHistory={() => {}}
+            />
+          );
+        })}
+      </div>
+
+      <AddExerciseInput allExercises={exercises} onAdd={addExerciseByName} />
+
+      <div className="flex justify-end gap-2">
+        <Button variant="secondary" onClick={onCancel}>
+          Cancel
+        </Button>
+        <Button
+          variant="primary"
+          onClick={handleSave}
+          disabled={!name.trim() || items.length === 0}
+        >
+          {routine ? "Save changes" : "Save routine"}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/RoutineList.jsx
+++ b/src/components/RoutineList.jsx
@@ -1,0 +1,220 @@
+import React, { useState } from "react";
+import { useApp } from "../context/AppContext";
+import { useConfirm } from "./ConfirmDialog";
+import { Button } from "./ui/Button";
+import { Card, CardContent } from "./ui/Card";
+import { Badge } from "./ui/Badge";
+import RoutineEditor from "./RoutineEditor";
+import WorkoutPlanner from "./WorkoutPlanner";
+
+function muscleChips(exercises, exerciseDb) {
+  const muscles = new Set();
+  for (const we of exercises) {
+    const ex = exerciseDb.find((e) => e.name === we.exerciseName);
+    if (ex?.mainMuscle) muscles.add(ex.mainMuscle);
+  }
+  return [...muscles].slice(0, 3);
+}
+
+function ExerciseChips({ exercises }) {
+  const names = exercises.map((we) => we.exerciseName);
+  const visible = names.slice(0, 3);
+  const rest = names.length - visible.length;
+  return (
+    <div className="flex flex-wrap gap-1 mt-2">
+      {visible.map((n) => (
+        <Badge key={n}>{n}</Badge>
+      ))}
+      {rest > 0 && <Badge>+{rest}</Badge>}
+    </div>
+  );
+}
+
+export default function RoutineList() {
+  const {
+    routines,
+    exercises,
+    saveRoutine,
+    updateRoutine,
+    deleteRoutine,
+    startRoutine,
+  } = useApp();
+  const confirm = useConfirm();
+
+  // null = list view; "new" = new editor; routine.id = editing that routine
+  const [editing, setEditing] = useState(null);
+  // routine being planned (shown in a WorkoutPlanner-like date picker)
+  const [planning, setPlanning] = useState(null);
+  // which card has its ⋯ menu open
+  const [openMenu, setOpenMenu] = useState(null);
+
+  if (planning) {
+    return (
+      <div className="space-y-4">
+        <div className="flex items-center gap-2">
+          <Button variant="secondary" onClick={() => setPlanning(null)}>
+            ← Back
+          </Button>
+          <h2 className="text-base font-semibold">Plan: {planning.name}</h2>
+        </div>
+        <WorkoutPlanner
+          prefillRoutine={planning}
+          onCreated={() => setPlanning(null)}
+        />
+      </div>
+    );
+  }
+
+  if (editing !== null) {
+    const existing =
+      editing === "new" ? null : routines.find((r) => r.id === editing);
+    return (
+      <div className="space-y-4">
+        <div className="flex items-center gap-2">
+          <Button variant="secondary" onClick={() => setEditing(null)}>
+            ← Back
+          </Button>
+          <h2 className="text-base font-semibold">
+            {editing === "new"
+              ? "New routine"
+              : `Edit: ${existing?.name ?? ""}`}
+          </h2>
+        </div>
+        <Card>
+          <CardContent>
+            <RoutineEditor
+              routine={existing}
+              onSave={(saved) => {
+                if (editing === "new") saveRoutine(saved);
+                else updateRoutine(saved.id, saved);
+                setEditing(null);
+              }}
+              onCancel={() => setEditing(null)}
+            />
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {routines.length === 0 && (
+        <Card>
+          <CardContent>
+            <p className="text-sm text-neutral-500 dark:text-neutral-400">
+              No routines yet. Save a workout as a routine from history, or
+              create one from scratch.
+            </p>
+          </CardContent>
+        </Card>
+      )}
+
+      {routines.map((r) => {
+        const chips = muscleChips(r.exercises, exercises);
+        return (
+          <Card key={r.id}>
+            <CardContent>
+              <div className="flex items-start justify-between gap-2">
+                <div className="min-w-0">
+                  <div className="font-semibold text-neutral-900 dark:text-neutral-100 truncate">
+                    {r.name}
+                  </div>
+                  <div className="text-xs text-neutral-500 dark:text-neutral-400 mt-0.5">
+                    {r.exercises.length} exercise
+                    {r.exercises.length !== 1 ? "s" : ""}
+                    {chips.length > 0 && ` · ${chips.join(", ")}`}
+                  </div>
+                </div>
+                <div className="relative">
+                  <Button
+                    variant="ghost"
+                    onClick={() => setOpenMenu(openMenu === r.id ? null : r.id)}
+                    aria-label="More options"
+                  >
+                    ⋯
+                  </Button>
+                  {openMenu === r.id && (
+                    <div
+                      className="absolute right-0 z-10 mt-1 w-40 rounded-xl border bg-white shadow-sm dark:border-neutral-700 dark:bg-neutral-900"
+                      onBlur={() => setOpenMenu(null)}
+                    >
+                      <button
+                        className="w-full px-4 py-2.5 text-left text-sm hover:bg-neutral-50 dark:hover:bg-neutral-800 rounded-t-xl"
+                        onClick={() => {
+                          setEditing(r.id);
+                          setOpenMenu(null);
+                        }}
+                      >
+                        Edit
+                      </button>
+                      <button
+                        className="w-full px-4 py-2.5 text-left text-sm hover:bg-neutral-50 dark:hover:bg-neutral-800"
+                        onClick={() => {
+                          saveRoutine({
+                            ...r,
+                            id: undefined,
+                            name: `${r.name} (copy)`,
+                            createdAt: Date.now(),
+                            updatedAt: Date.now(),
+                          });
+                          setOpenMenu(null);
+                        }}
+                      >
+                        Duplicate
+                      </button>
+                      <button
+                        className="w-full px-4 py-2.5 text-left text-sm text-red-600 hover:bg-neutral-50 dark:hover:bg-neutral-800 rounded-b-xl"
+                        onClick={() => {
+                          setOpenMenu(null);
+                          confirm({
+                            title: `Delete "${r.name}"?`,
+                            message:
+                              "This removes the routine. Past workouts are not affected.",
+                            confirmText: "Delete",
+                            tone: "destructive",
+                          }).then((ok) => {
+                            if (ok) deleteRoutine(r.id);
+                          });
+                        }}
+                      >
+                        Delete
+                      </button>
+                    </div>
+                  )}
+                </div>
+              </div>
+
+              <ExerciseChips exercises={r.exercises} />
+
+              <div className="flex gap-2 mt-3">
+                <button
+                  type="button"
+                  onClick={() => startRoutine(r.id)}
+                  className="flex-1 rounded-xl bg-blue-600 py-2 text-sm font-medium text-white transition hover:bg-blue-700"
+                >
+                  ▶ Start
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setPlanning(r)}
+                  className="flex-1 rounded-xl border py-2 text-sm font-medium text-neutral-700 transition hover:bg-neutral-50 dark:border-neutral-700 dark:text-neutral-200 dark:hover:bg-neutral-800"
+                >
+                  Plan
+                </button>
+              </div>
+            </CardContent>
+          </Card>
+        );
+      })}
+
+      <button
+        type="button"
+        onClick={() => setEditing("new")}
+        className="w-full rounded-xl border border-dashed py-3 text-sm text-neutral-500 transition hover:bg-neutral-50 dark:border-neutral-700 dark:text-neutral-400 dark:hover:bg-neutral-900"
+      >
+        + New routine
+      </button>
+    </div>
+  );
+}

--- a/src/components/RoutinePicker.jsx
+++ b/src/components/RoutinePicker.jsx
@@ -1,0 +1,59 @@
+import React, { useState, useRef, useEffect } from "react";
+import { useApp } from "../context/AppContext";
+
+/**
+ * A button that opens a dropdown of saved routines.
+ * onPick(routine) is called when the user selects one.
+ */
+export default function RoutinePicker({ onPick, label = "Load routine" }) {
+  const { routines } = useApp();
+  const [open, setOpen] = useState(false);
+  const ref = useRef(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e) => {
+      if (ref.current && !ref.current.contains(e.target)) setOpen(false);
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [open]);
+
+  if (routines.length === 0) return null;
+
+  return (
+    <div className="relative" ref={ref}>
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        className="flex w-full items-center justify-between rounded-xl border border-blue-200 bg-blue-50 px-3 py-2 text-sm font-medium text-blue-700 transition hover:bg-blue-100 dark:border-blue-900 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
+      >
+        <span>📋 {label}</span>
+        <span className="ml-2 text-xs opacity-70">▾</span>
+      </button>
+      {open && (
+        <div className="absolute left-0 right-0 z-20 mt-1 rounded-xl border bg-white shadow-md dark:border-neutral-700 dark:bg-neutral-900">
+          {routines.map((r) => (
+            <button
+              key={r.id}
+              type="button"
+              className="flex w-full items-center justify-between px-4 py-2.5 text-left text-sm hover:bg-neutral-50 first:rounded-t-xl last:rounded-b-xl dark:hover:bg-neutral-800"
+              onClick={() => {
+                onPick(r);
+                setOpen(false);
+              }}
+            >
+              <span className="font-medium text-neutral-900 dark:text-neutral-100">
+                {r.name}
+              </span>
+              <span className="text-xs text-neutral-500 dark:text-neutral-400">
+                {r.exercises.length} exercise
+                {r.exercises.length !== 1 ? "s" : ""}
+              </span>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/WorkoutHistoryItem.jsx
+++ b/src/components/WorkoutHistoryItem.jsx
@@ -42,7 +42,7 @@ export default function WorkoutHistoryItem({
   onShowHistory,
 }) {
   const confirm = useConfirm();
-  const { startSession } = useApp();
+  const { startSession, saveRoutineFromWorkout } = useApp();
 
   return (
     <div className="rounded-2xl border dark:border-neutral-800">
@@ -56,6 +56,20 @@ export default function WorkoutHistoryItem({
         <div className="flex items-center gap-2">
           <Button variant="primary" onClick={() => startSession(w.id)}>
             ▶ Start
+          </Button>
+          <Button
+            variant="secondary"
+            onClick={() => {
+              saveRoutineFromWorkout(w);
+              confirm({
+                title: "Saved as routine",
+                message: `"${w.name}" added to your routines. Edit it any time from the Routines tab.`,
+                confirmText: "OK",
+                tone: "neutral",
+              });
+            }}
+          >
+            Save as routine
           </Button>
           <Button variant="secondary" onClick={onToggle}>
             Details <ChevronDown open={expanded} />

--- a/src/components/WorkoutPlanner.jsx
+++ b/src/components/WorkoutPlanner.jsx
@@ -13,17 +13,26 @@ import { useApp } from "../context/AppContext";
 import { moveItem } from "../lib/arrayUtils";
 import { MAX_SETS } from "../lib/constants";
 import { normalizeRpe, normalizeFeedback } from "../lib/rpe";
+import { instantiateRoutine } from "../lib/routines";
+import RoutinePicker from "./RoutinePicker";
 
 /**
  * Planner component for creating a new workout.  Uses AppContext
  * for exercises, workouts and unit; onCreated callback remains optional.
  */
-export default function WorkoutPlanner({ onCreated }) {
+export default function WorkoutPlanner({ onCreated, prefillRoutine = null }) {
   const { exercises, setExercises, workouts, setWorkouts, unit } = useApp();
 
   const [dates, setDates] = useState([todayStr()]);
-  const [name, setName] = useState("");
-  const [items, setItems] = useState([]);
+  const [name, setName] = useState(prefillRoutine?.name ?? "");
+  const [items, setItems] = useState(() => {
+    if (!prefillRoutine) return [];
+    const w = instantiateRoutine(prefillRoutine, {
+      date: todayStr(),
+      exercises,
+    });
+    return w.exercises;
+  });
   const confirm = useConfirm();
   const [historyExercise, setHistoryExercise] = useState(null);
 
@@ -86,6 +95,18 @@ export default function WorkoutPlanner({ onCreated }) {
         </div>
 
         <div className="grid gap-3">
+          {/* Load routine picker */}
+          <RoutinePicker
+            onPick={(routine) => {
+              const w = instantiateRoutine(routine, {
+                date: dates[0] || todayStr(),
+                exercises,
+              });
+              setName(routine.name);
+              setItems(w.exercises);
+            }}
+          />
+
           {/* Date inputs */}
           <div className="space-y-2">
             <label className="text-xs text-neutral-600 dark:text-neutral-300">

--- a/src/components/WorkoutsTab.jsx
+++ b/src/components/WorkoutsTab.jsx
@@ -4,6 +4,7 @@ import { useApp } from "../context/AppContext";
 import WorkoutPlanner from "./WorkoutPlanner";
 import WorkoutHistory from "./WorkoutHistory";
 import CalendarView from "./CalendarView";
+import RoutineList from "./RoutineList";
 
 /**
  * Workouts destination. Holds the planner + history list ("List"), with the
@@ -22,6 +23,7 @@ export default function WorkoutsTab() {
         <Segmented
           options={[
             ["list", "List"],
+            ["routines", "Routines"],
             ["calendar", "Calendar"],
           ]}
           value={view}
@@ -29,7 +31,7 @@ export default function WorkoutsTab() {
         />
       </div>
 
-      {view === "list" ? (
+      {view === "list" && (
         <>
           <button
             type="button"
@@ -41,9 +43,9 @@ export default function WorkoutsTab() {
           <WorkoutPlanner />
           <WorkoutHistory />
         </>
-      ) : (
-        <CalendarView />
       )}
+      {view === "routines" && <RoutineList />}
+      {view === "calendar" && <CalendarView />}
     </div>
   );
 }

--- a/src/context/AppContext.jsx
+++ b/src/context/AppContext.jsx
@@ -10,7 +10,9 @@ import {
   K_TAB,
   K_THEME,
   K_SESSION,
+  K_ROUTINES,
 } from "../lib/storage";
+import { routineFromWorkout, instantiateRoutine } from "../lib/routines";
 import { applyTheme } from "../lib/theme";
 import { ymdFromDate } from "../lib/date";
 
@@ -32,6 +34,7 @@ export function AppProvider({ children }) {
   // In-progress live-logging session (or null). Persisted so a refresh mid-set
   // resumes where you left off.
   const [session, setSession] = useState(() => loadLS(K_SESSION, null));
+  const [routines, setRoutines] = useState(() => loadLS(K_ROUTINES, []));
 
   // Persist tab and unit when they change
   useEffect(() => saveLS(K_TAB, tab), [tab]);
@@ -56,6 +59,7 @@ export function AppProvider({ children }) {
   useEffect(() => saveLS(K_EX, exercises), [exercises]);
   useEffect(() => saveLS(K_WO, workouts), [workouts]);
   useEffect(() => saveLS(K_SESSION, session), [session]);
+  useEffect(() => saveLS(K_ROUTINES, routines), [routines]);
 
   // Start a live-logging session for an existing workout.
   const startSession = (workoutId) =>
@@ -72,6 +76,44 @@ export function AppProvider({ children }) {
     startSession(w.id);
   };
   const endSession = () => setSession(null);
+
+  const saveRoutine = (routine) => setRoutines((prev) => [routine, ...prev]);
+
+  const updateRoutine = (id, patch) =>
+    setRoutines((prev) =>
+      prev.map((r) =>
+        r.id === id ? { ...r, ...patch, updatedAt: Date.now() } : r,
+      ),
+    );
+
+  const deleteRoutine = (id) =>
+    setRoutines((prev) => prev.filter((r) => r.id !== id));
+
+  const startRoutine = (id) => {
+    const routine = routines.find((r) => r.id === id);
+    if (!routine) return;
+    const w = instantiateRoutine(routine, {
+      date: ymdFromDate(new Date()),
+      exercises,
+    });
+    setWorkouts((prev) =>
+      [w, ...prev].sort((a, b) => (a.date < b.date ? 1 : -1)),
+    );
+    startSession(w.id);
+  };
+
+  const addWorkoutFromRoutine = (id, date) => {
+    const routine = routines.find((r) => r.id === id);
+    if (!routine) return null;
+    const w = instantiateRoutine(routine, { date, exercises });
+    setWorkouts((prev) =>
+      [w, ...prev].sort((a, b) => (a.date < b.date ? 1 : -1)),
+    );
+    return w;
+  };
+
+  const saveRoutineFromWorkout = (workout) =>
+    saveRoutine(routineFromWorkout(workout));
 
   // Update each exercise’s lastWorkout property whenever workouts change
   useEffect(() => {
@@ -123,6 +165,14 @@ export function AppProvider({ children }) {
         startSession,
         startEmptyWorkout,
         endSession,
+        routines,
+        setRoutines,
+        saveRoutine,
+        updateRoutine,
+        deleteRoutine,
+        startRoutine,
+        addWorkoutFromRoutine,
+        saveRoutineFromWorkout,
       }}
     >
       {children}

--- a/src/lib/backup.js
+++ b/src/lib/backup.js
@@ -1,6 +1,8 @@
 import { todayStr, uuid } from "./storage";
 import { MAX_SETS } from "./constants";
 import { normalizeRpe, normalizeFeedback } from "./rpe";
+import { normalizeRoutine, mergeRoutines } from "./routines";
+export { mergeRoutines };
 
 export function downloadJSON(filename, data) {
   const blob = new Blob([JSON.stringify(data, null, 2)], {
@@ -64,7 +66,10 @@ export function normalizeData(obj) {
   const workouts = (Array.isArray(obj?.workouts) ? obj.workouts : [])
     .map(normalizeWorkout)
     .filter(Boolean);
-  return { exercises, workouts };
+  const routines = (Array.isArray(obj?.routines) ? obj.routines : [])
+    .map(normalizeRoutine)
+    .filter(Boolean);
+  return { exercises, workouts, routines };
 }
 
 export function mergeExercises(current, incoming) {

--- a/src/lib/backup.test.js
+++ b/src/lib/backup.test.js
@@ -130,10 +130,15 @@ describe("normalizeWorkout", () => {
 
 describe("normalizeData", () => {
   it("returns empty arrays for garbage input", () => {
-    expect(normalizeData(null)).toEqual({ exercises: [], workouts: [] });
+    expect(normalizeData(null)).toEqual({
+      exercises: [],
+      workouts: [],
+      routines: [],
+    });
     expect(normalizeData({ exercises: "nope", workouts: 42 })).toEqual({
       exercises: [],
       workouts: [],
+      routines: [],
     });
   });
 

--- a/src/lib/routines.js
+++ b/src/lib/routines.js
@@ -1,0 +1,123 @@
+import { uuid, todayStr } from "./storage";
+import { MAX_SETS } from "./constants";
+import { normalizeRpe, normalizeFeedback } from "./rpe";
+
+/**
+ * Build a Routine from a completed Workout.
+ * Strips date/id, preserves the exercise+rep structure, resets RPE/feedback.
+ */
+export function routineFromWorkout(workout) {
+  return {
+    id: uuid(),
+    name: (workout.name || "").trim() || todayStr(),
+    exercises: (workout.exercises || []).slice(0, MAX_SETS).map((we) => ({
+      exerciseName: we.exerciseName,
+      sets: (we.sets || []).slice(0, MAX_SETS).map((s, idx) => ({
+        set: idx + 1,
+        weight: Number(s.weight) || 0,
+        reps: Number(s.reps) || 0,
+      })),
+      rpe: null,
+      feedback: "",
+    })),
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  };
+}
+
+/**
+ * Instantiate a Routine into a Workout for a given date.
+ * Weights are pulled from the exercise's lastWorkout (last set); falls back to
+ * the routine's stored weight if no history exists. Rep targets always come
+ * from the routine.
+ *
+ * @param {object} routine
+ * @param {{ date: string, exercises: object[] }} ctx  exercises = exercise database
+ * @returns {object} a Workout
+ */
+export function instantiateRoutine(routine, { date, exercises = [] }) {
+  const d = date || todayStr();
+  const exMap = new Map(
+    (exercises || []).map((e) => [e.name.toLowerCase(), e]),
+  );
+
+  return {
+    id: uuid(),
+    date: d,
+    name: routine.name,
+    exercises: (routine.exercises || []).map((we) => {
+      const dbEx = exMap.get((we.exerciseName || "").toLowerCase());
+      const lastSets = dbEx?.lastWorkout?.sets;
+      const historyWeight = lastSets?.length
+        ? Number(lastSets.at(-1).weight) || 0
+        : null;
+
+      return {
+        exerciseName: we.exerciseName,
+        sets: (we.sets || []).map((s, idx) => ({
+          set: idx + 1,
+          weight:
+            historyWeight !== null ? historyWeight : Number(s.weight) || 0,
+          reps: Number(s.reps) || 0,
+        })),
+        rpe: null,
+        feedback: "",
+      };
+    }),
+  };
+}
+
+/**
+ * Validate and normalise a routine from an import payload.
+ * Returns null for unrecoverable rows.
+ */
+export function normalizeRoutine(r) {
+  const name = String(r?.name || "").trim();
+  if (!name) return null;
+  const id = typeof r?.id === "string" && r.id ? r.id : uuid();
+  const exercises = (Array.isArray(r?.exercises) ? r.exercises : [])
+    .map((we) => {
+      const exerciseName = String(we?.exerciseName || "").trim();
+      if (!exerciseName) return null;
+      const setsRaw = Array.isArray(we?.sets) ? we.sets : [];
+      const sets = setsRaw.slice(0, MAX_SETS).map((s, idx) => ({
+        set: idx + 1,
+        weight: Number(s?.weight) || 0,
+        reps: Number(s?.reps) || 0,
+      }));
+      return {
+        exerciseName,
+        sets: sets.length ? sets : [{ set: 1, weight: 0, reps: 0 }],
+        rpe: normalizeRpe(we?.rpe),
+        feedback: normalizeFeedback(we?.feedback),
+      };
+    })
+    .filter(Boolean);
+  if (!exercises.length) return null;
+  return {
+    id,
+    name,
+    exercises,
+    createdAt: Number(r?.createdAt) || Date.now(),
+    updatedAt: Number(r?.updatedAt) || Date.now(),
+  };
+}
+
+/**
+ * Merge incoming routines into the current set.
+ * Id collisions get a fresh uuid (same strategy as mergeWorkouts).
+ * Result sorted by updatedAt descending.
+ */
+export function mergeRoutines(current, incoming) {
+  const ids = new Set(current.map((r) => r.id));
+  const merged = [...current];
+  for (const r of incoming) {
+    if (!ids.has(r.id)) {
+      ids.add(r.id);
+      merged.push(r);
+    } else {
+      merged.push({ ...r, id: uuid() });
+    }
+  }
+  return merged.sort((a, b) => b.updatedAt - a.updatedAt);
+}

--- a/src/lib/routines.test.js
+++ b/src/lib/routines.test.js
@@ -1,0 +1,253 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  routineFromWorkout,
+  instantiateRoutine,
+  normalizeRoutine,
+  mergeRoutines,
+} from "./routines";
+import { MAX_SETS } from "./constants";
+
+vi.mock("./storage", () => ({
+  uuid: vi.fn(() => "test-uuid"),
+  todayStr: vi.fn(() => "2026-06-17"),
+}));
+
+const makeWorkout = (overrides = {}) => ({
+  id: "w1",
+  date: "2026-06-16",
+  name: "Push Day",
+  exercises: [
+    {
+      exerciseName: "Bench Press",
+      sets: [
+        { set: 1, weight: 60, reps: 8 },
+        { set: 2, weight: 60, reps: 8 },
+      ],
+      rpe: 8,
+      feedback: "good",
+    },
+    {
+      exerciseName: "OHP",
+      sets: [{ set: 1, weight: 40, reps: 10 }],
+      rpe: null,
+      feedback: "",
+    },
+  ],
+  ...overrides,
+});
+
+describe("routineFromWorkout", () => {
+  it("strips date and produces a new id", () => {
+    const r = routineFromWorkout(makeWorkout());
+    expect(r.id).toBe("test-uuid");
+    expect(r).not.toHaveProperty("date");
+  });
+
+  it("preserves name and exercises", () => {
+    const r = routineFromWorkout(makeWorkout());
+    expect(r.name).toBe("Push Day");
+    expect(r.exercises).toHaveLength(2);
+    expect(r.exercises[0].exerciseName).toBe("Bench Press");
+  });
+
+  it("resets rpe and feedback on each exercise", () => {
+    const r = routineFromWorkout(makeWorkout());
+    for (const we of r.exercises) {
+      expect(we.rpe).toBeNull();
+      expect(we.feedback).toBe("");
+    }
+  });
+
+  it("preserves rep scheme from sets", () => {
+    const r = routineFromWorkout(makeWorkout());
+    expect(r.exercises[0].sets[0].reps).toBe(8);
+    expect(r.exercises[1].sets[0].reps).toBe(10);
+  });
+
+  it("caps sets at MAX_SETS", () => {
+    const sets = Array.from({ length: MAX_SETS + 3 }, (_, i) => ({
+      set: i + 1,
+      weight: 50,
+      reps: 5,
+    }));
+    const w = makeWorkout({
+      exercises: [{ exerciseName: "Squat", sets, rpe: null, feedback: "" }],
+    });
+    const r = routineFromWorkout(w);
+    expect(r.exercises[0].sets).toHaveLength(MAX_SETS);
+  });
+
+  it("sets timestamps", () => {
+    const before = Date.now();
+    const r = routineFromWorkout(makeWorkout());
+    expect(r.createdAt).toBeGreaterThanOrEqual(before);
+    expect(r.updatedAt).toBeGreaterThanOrEqual(before);
+  });
+});
+
+describe("instantiateRoutine", () => {
+  const routine = {
+    id: "r1",
+    name: "Push Day A",
+    exercises: [
+      {
+        exerciseName: "Bench Press",
+        sets: [{ set: 1, weight: 55, reps: 8 }],
+        rpe: null,
+        feedback: "",
+      },
+      {
+        exerciseName: "OHP",
+        sets: [{ set: 1, weight: 35, reps: 10 }],
+        rpe: null,
+        feedback: "",
+      },
+    ],
+    createdAt: 0,
+    updatedAt: 0,
+  };
+
+  const exercises = [
+    {
+      name: "Bench Press",
+      lastWorkout: {
+        sets: [
+          { set: 1, weight: 60, reps: 8 },
+          { set: 2, weight: 62, reps: 6 },
+        ],
+      },
+    },
+    {
+      name: "OHP",
+      lastWorkout: null,
+    },
+  ];
+
+  it("creates a workout with the given date", () => {
+    const w = instantiateRoutine(routine, { date: "2026-06-17", exercises });
+    expect(w.date).toBe("2026-06-17");
+    expect(w.name).toBe("Push Day A");
+  });
+
+  it("pulls weight from last set of lastWorkout", () => {
+    const w = instantiateRoutine(routine, { date: "2026-06-17", exercises });
+    expect(w.exercises[0].sets[0].weight).toBe(62);
+  });
+
+  it("falls back to routine weight when no history", () => {
+    const w = instantiateRoutine(routine, { date: "2026-06-17", exercises });
+    expect(w.exercises[1].sets[0].weight).toBe(35);
+  });
+
+  it("preserves rep targets from routine", () => {
+    const w = instantiateRoutine(routine, { date: "2026-06-17", exercises });
+    expect(w.exercises[0].sets[0].reps).toBe(8);
+    expect(w.exercises[1].sets[0].reps).toBe(10);
+  });
+
+  it("resets rpe and feedback", () => {
+    const w = instantiateRoutine(routine, { date: "2026-06-17", exercises });
+    for (const we of w.exercises) {
+      expect(we.rpe).toBeNull();
+      expect(we.feedback).toBe("");
+    }
+  });
+
+  it("falls back to todayStr when no date provided", () => {
+    const w = instantiateRoutine(routine, { exercises });
+    expect(w.date).toBe("2026-06-17");
+  });
+
+  it("handles empty exercises array gracefully", () => {
+    const w = instantiateRoutine(routine, {
+      date: "2026-06-17",
+      exercises: [],
+    });
+    expect(w.exercises[0].sets[0].weight).toBe(55);
+  });
+});
+
+describe("normalizeRoutine", () => {
+  it("returns null for missing name", () => {
+    expect(
+      normalizeRoutine({
+        exercises: [{ exerciseName: "Squat", sets: [{ weight: 0, reps: 5 }] }],
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null for empty exercises", () => {
+    expect(normalizeRoutine({ name: "Push", exercises: [] })).toBeNull();
+  });
+
+  it("normalizes a valid routine", () => {
+    const r = normalizeRoutine({
+      id: "r1",
+      name: "Push Day",
+      exercises: [
+        { exerciseName: "Bench Press", sets: [{ weight: 60, reps: 8 }] },
+      ],
+      createdAt: 1000,
+      updatedAt: 2000,
+    });
+    expect(r).not.toBeNull();
+    expect(r.name).toBe("Push Day");
+    expect(r.id).toBe("r1");
+    expect(r.exercises[0].exerciseName).toBe("Bench Press");
+    expect(r.createdAt).toBe(1000);
+  });
+
+  it("generates id when missing", () => {
+    const r = normalizeRoutine({
+      name: "Leg Day",
+      exercises: [{ exerciseName: "Squat", sets: [{ weight: 0, reps: 5 }] }],
+    });
+    expect(r.id).toBe("test-uuid");
+  });
+
+  it("filters out exercises with no name", () => {
+    const r = normalizeRoutine({
+      name: "Push",
+      exercises: [
+        { exerciseName: "", sets: [{ weight: 0, reps: 5 }] },
+        { exerciseName: "Bench Press", sets: [{ weight: 60, reps: 8 }] },
+      ],
+    });
+    expect(r.exercises).toHaveLength(1);
+  });
+});
+
+describe("mergeRoutines", () => {
+  const r1 = {
+    id: "r1",
+    name: "Push",
+    exercises: [],
+    createdAt: 100,
+    updatedAt: 200,
+  };
+  const r2 = {
+    id: "r2",
+    name: "Pull",
+    exercises: [],
+    createdAt: 100,
+    updatedAt: 300,
+  };
+
+  it("appends new routines", () => {
+    const merged = mergeRoutines([r1], [r2]);
+    expect(merged).toHaveLength(2);
+  });
+
+  it("re-ids collisions", () => {
+    const incoming = [{ ...r1, name: "Push v2" }];
+    const merged = mergeRoutines([r1], incoming);
+    expect(merged).toHaveLength(2);
+    const ids = merged.map((r) => r.id);
+    expect(new Set(ids).size).toBe(2);
+  });
+
+  it("sorts by updatedAt descending", () => {
+    const merged = mergeRoutines([r1], [r2]);
+    expect(merged[0].updatedAt).toBeGreaterThanOrEqual(merged[1].updatedAt);
+  });
+});

--- a/src/lib/storage.js
+++ b/src/lib/storage.js
@@ -21,6 +21,8 @@ export const K_WEIGHT_LOGS = "weightLogs";
 export const K_PROFILE = "mgym.profile.v1";
 /** localStorage key for the FitnessVolt strength-standards response cache. */
 export const K_FV_CACHE = "mgym.fvCache.v1";
+/** localStorage key for saved reusable routines (Routine[]). */
+export const K_ROUTINES = "mgym.routines.v1";
 
 /** Today's date as a `YYYY-MM-DD` string (UTC-sliced). */
 export const todayStr = () => new Date().toISOString().slice(0, 10);


### PR DESCRIPTION
## Summary

- **Save workouts as routines** — "Save as routine" action on every history card and on the live session finish bar. One tap saves the exercise structure, rep scheme, and order as a reusable template.
- **Routines tab** — new "Routines" toggle in the Workouts segmented control. Cards show name, exercise count, muscle summary, and first few exercises. Each card has **Start** (creates a dated workout and drops into the live session today, weights pulled from last performance), **Plan** (pre-fills the planner with a date picker), and **⋯** (edit, duplicate, delete).
- **Routine editor** — dateless planner reusing `AddExerciseInput` + `WorkoutExerciseEditor`. Create from scratch or edit any saved routine.
- **Load routine in the Planner** — a "Load routine" picker at the top of Plan/Log Workout pre-fills name + exercise list. User can adjust anything before saving.
- **From routine in Calendar** — a "From routine" button next to "New" instantiates a routine directly onto the selected day.
- **Backup** — routines included in JSON export and restored via merge or replace on import.

## Weight strategy

Template stores the rep scheme only. At instantiation, each lift's weight is pulled from that exercise's `lastWorkout` last set. Falls back to the routine's stored weight if no history exists.

## Files

New: `src/lib/routines.js` (+21 tests), `src/components/RoutineEditor.jsx`, `src/components/RoutineList.jsx`, `src/components/RoutinePicker.jsx`

Touched: `storage.js` (K_ROUTINES), `AppContext.jsx` (routines state + 6 actions), `WorkoutsTab.jsx`, `WorkoutPlanner.jsx`, `CalendarView.jsx`, `WorkoutHistoryItem.jsx`, `LiveSession.jsx`, `backup.js`, `DataManagementMenu.jsx`, `backup.test.js`

## Test plan

- [ ] Workouts → Routines toggle shows empty state and "New routine" button
- [ ] Create a routine from scratch in the editor; verify it appears as a card
- [ ] Log a workout → expand in history → "Save as routine" → appears in Routines
- [ ] "Save as routine" during a live session
- [ ] Start a routine → live session opens with today's date and history weights prefilled
- [ ] Plan a routine → planner opens with name + exercises prefilled, date editable
- [ ] Edit a routine → changes persist
- [ ] Duplicate a routine → copy appears with "(copy)" suffix
- [ ] Delete a routine → useConfirm fires, card removed
- [ ] Workouts → List → "Load routine" picker → planner fills name + exercises
- [ ] Calendar → select a day → "From routine" → workout appears on that day
- [ ] Export backup → JSON contains `routines` array
- [ ] Import backup (merge) → routines merged without clobbering existing
- [ ] Import backup (replace) → routines replaced

🤖 Generated with [Claude Code](https://claude.com/claude-code)