### PR TITLE
Replace Save as routine text button with icon

### DIFF
--- a/src/components/WorkoutHistoryItem.jsx
+++ b/src/components/WorkoutHistoryItem.jsx
@@ -58,7 +58,9 @@ export default function WorkoutHistoryItem({
             ▶ Start
           </Button>
           <Button
-            variant="secondary"
+            variant="ghost"
+            aria-label="Save as routine"
+            title="Save as routine"
             onClick={() => {
               saveRoutineFromWorkout(w);
               confirm({
@@ -69,7 +71,7 @@ export default function WorkoutHistoryItem({
               });
             }}
           >
-            Save as routine
+            📋
           </Button>
           <Button variant="secondary" onClick={onToggle}>
             Details <ChevronDown open={expanded} />


### PR DESCRIPTION
## Summary

- The "Save as routine" button in the workout history card header was too wide and disrupted the row layout alongside ▶ Start, Details, and Delete.
- Replaced with a ghost icon button (📋) with `aria-label="Save as routine"` and a `title` tooltip for discoverability — same visual footprint as the existing trash icon.

## Test plan

- [ ] Open Workouts → List → expand a history card — header row is compact with the 📋 icon visible
- [ ] Tap 📋 → confirm dialog appears and routine is saved
- [ ] Hover 📋 on desktop → tooltip reads "Save as routine"

🤖 Generated with [Claude Code](https://claude.com/claude-code)