### PR TITLE
Reorder workout history card buttons

### DIFF
--- a/src/components/WorkoutHistoryItem.jsx
+++ b/src/components/WorkoutHistoryItem.jsx
@@ -54,6 +54,9 @@ export default function WorkoutHistoryItem({
           </div>
         </div>
         <div className="flex items-center gap-2">
+          <Button variant="secondary" onClick={onToggle}>
+            Details <ChevronDown open={expanded} />
+          </Button>
           <Button variant="primary" onClick={() => startSession(w.id)}>
             ▶ Start
           </Button>
@@ -72,9 +75,6 @@ export default function WorkoutHistoryItem({
             }}
           >
             📋
-          </Button>
-          <Button variant="secondary" onClick={onToggle}>
-            Details <ChevronDown open={expanded} />
           </Button>
           <Button
             variant="ghost"


### PR DESCRIPTION
## Summary

- Reorders the action buttons in the workout history card header to: **Details → ▶ Start → 📋 → 🗑**
- Previous order had Start first, which buried the Details toggle — the most commonly tapped action — behind the primary CTA.

## Test plan

- [ ] Workouts → List → confirm button order in each history card reads Details, Start, 📋, 🗑

🤖 Generated with [Claude Code](https://claude.com/claude-code)