### PR TITLE
Add MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Dang Phu Thinh
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "gym-tracker",
   "private": true,
   "version": "1.1.0",
+  "license": "MIT",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## What

- Add a `LICENSE` file with the MIT License text, © 2026 Dang Phu Thinh.
- Declare `"license": "MIT"` in `package.json`.

## Why

The repo previously had no license, which by default means "all rights reserved" — no one (including the author across machines/forks) has clear permission to use, copy, or modify it. This is a personal, non-commercial workout tracker, so MIT is the right fit: maximally permissive for learning/reuse while disclaiming warranty and liability to protect the author.

## Notes for reviewer

- MIT was chosen over GPL since there's no desire to enforce copyleft, and over CC-NC since Creative Commons licenses aren't designed for software.
- GitHub will auto-detect the `LICENSE` file and surface an MIT badge on the repo page once merged.