### PR TITLE
Add security scanning and CI workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  # npm dependencies (runtime + dev)
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      # Batch minor/patch dev-tooling bumps into one PR to cut noise.
+      dev-dependencies:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
+
+  # Keep the GitHub Actions used in workflows up to date.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,57 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Lint, format, test, build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Mirrors the husky pre-push gate so PRs from any clone are enforced.
+      - name: Run checks
+        run: npm run check
+
+  audit:
+    name: npm audit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Gate on production deps only — these ship in the bundle users load.
+      # Dev-only advisories (e.g. the esbuild dev-server issue via vite) can't
+      # reach shipped code, so they must not block PRs; Dependabot still alerts
+      # on them, and the informational step below keeps them visible.
+      - name: Audit production dependencies
+        run: npm audit --omit=dev --audit-level=moderate
+
+      - name: Audit all dependencies (informational)
+        run: npm audit --audit-level=moderate || true

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,31 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly run catches newly-published queries against unchanged code.
+    - cron: "27 4 * * 1"
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze JS/JSX
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: javascript-typescript
+          queries: security-and-quality
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
## What

Adds GitHub-native security scanning + CI, scoped to a client-only static SPA's real attack surface (the dependency tree and in-code JS), skipping scanners that don't apply (DAST, container/IaC scanning).

### Files
- **`.github/dependabot.yml`** — weekly npm + github-actions update PRs; dev-tooling minor/patch bumps grouped into one PR to cut noise.
- **`.github/workflows/codeql.yml`** — CodeQL JS/TS SAST (`security-and-quality` queries) on push, PR, and a weekly schedule.
- **`.github/workflows/ci.yml`** — two jobs:
  - `check`: `npm ci` + `npm run check` (lint + format + test + build) — mirrors the husky pre-push gate so PRs from any clone are enforced.
  - `audit`: `npm audit --omit=dev --audit-level=moderate` (blocking) + a full audit (informational).

## Why the audit gates on production deps only

There are currently 2 high-severity advisories — both the esbuild dev-server issue pulled in transitively via `vite`. `vite`/`esbuild` are **devDependencies**: the advisory only affects `npm run dev` and never reaches the static bundle users load. The only fix is `vite@8` (breaking). Gating a full audit would make CI red on day one over something that can't affect shipped code. Production-dep audit is clean (`found 0 vulnerabilities`); Dependabot + the informational step still keep the dev-dep advisories visible.

## Post-merge (repo settings, not in this PR)
- Enable **secret scanning + push protection** (Settings → Code security).
- CodeQL results surface under the **Security** tab once the workflow runs on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)