### PR TITLE
chore: skip Vercel preview builds for Dependabot branches

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "ignoreCommand": "if echo \"$VERCEL_GIT_COMMIT_REF\" | grep -q '^dependabot/'; then exit 0; else exit 1; fi"
+}


### PR DESCRIPTION
## What

Add a `vercel.json` `ignoreCommand` that skips the Vercel build whenever the branch ref starts with `dependabot/`.

## Why

Vercel builds a preview deployment for every pushed branch, including Dependabot's dependency-bump branches. Major bumps (e.g. vite 8 against the older `@vitejs/plugin-react`) fail peer resolution during `npm install`, producing recurring failed-build error logs.

With this in place, Dependabot branches no longer trigger (failing) preview deployments, while real feature branches and `main` still deploy normally.

Note: Vercel reads this file from the branch being built, so it only takes effect on Dependabot branches created **after** this lands on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)