### PR TITLE
Add Vercel Analytics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,9 @@
     "": {
       "name": "gym-tracker",
       "version": "1.1.0",
+      "license": "MIT",
       "dependencies": {
+        "@vercel/analytics": "^2.0.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "recharts": "^3.8.1"
@@ -1956,6 +1958,48 @@
       "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
       "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-2.0.1.tgz",
+      "integrity": "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "nuxt": ">= 3",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "nuxt": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "prepare": "husky"
   },
   "dependencies": {
+    "@vercel/analytics": "^2.0.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "recharts": "^3.8.1"

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
+import { Analytics } from "@vercel/analytics/react";
 import App from "./App.jsx";
 import "./index.css";
 import { ConfirmProvider } from "./components/ConfirmDialog";
@@ -9,5 +10,6 @@ ReactDOM.createRoot(document.getElementById("root")).render(
     <ConfirmProvider>
       <App />
     </ConfirmProvider>
+    <Analytics />
   </React.StrictMode>,
 );


### PR DESCRIPTION
## Summary
- Installs `@vercel/analytics` package
- Adds `<Analytics />` component from `@vercel/analytics/react` (Vite-compatible import) to `src/main.jsx`

## Notes
Uses the React/Vite import path (`@vercel/analytics/react`), not the Next.js one (`@vercel/analytics/next`). The component is placed inside `<React.StrictMode>` alongside the app root so it initializes on every page load and starts collecting page views once the Vercel deployment is live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)