### PR TITLE
Add notification ding when rest timer finishes

### DIFF
--- a/src/components/LiveSession.jsx
+++ b/src/components/LiveSession.jsx
@@ -13,6 +13,7 @@ import {
   restRemaining,
 } from "../lib/liveSession";
 import { moveItem } from "../lib/arrayUtils";
+import { unlockAudio, playDing } from "../lib/sound";
 import WeightRepInputs from "./WeightRepInputs";
 import AddExerciseInput from "./AddExerciseInput";
 import RpeFeedback from "./RpeFeedback";
@@ -69,6 +70,12 @@ export default function LiveSession() {
   // null while idle; once it reaches 0 the bar reverts to the presets below, so
   // `restLeft > 0` is treated as "timer running" and no clear-at-zero is needed.
   const restLeft = restRemaining(restEndsAt, nowTs);
+
+  const prevRestLeftRef = useRef(restLeft);
+  useEffect(() => {
+    if (prevRestLeftRef.current > 0 && restLeft === 0) playDing();
+    prevRestLeftRef.current = restLeft;
+  }, [restLeft]);
 
   // Drag-to-reorder the exercise chips. Pointer-based so it works on touch and
   // mouse alike (HTML5 drag-and-drop doesn't fire on touch).
@@ -509,7 +516,10 @@ export default function LiveSession() {
                 <button
                   key={secs}
                   type="button"
-                  onClick={() => setRestEndsAt(Date.now() + secs * 1000)}
+                  onClick={() => {
+                    unlockAudio();
+                    setRestEndsAt(Date.now() + secs * 1000);
+                  }}
                   className="flex-1 rounded-xl bg-neutral-100 py-2 text-sm font-medium text-neutral-700 transition hover:bg-neutral-200 dark:bg-neutral-800 dark:text-neutral-200 dark:hover:bg-neutral-700"
                 >
                   {label}

--- a/src/lib/sound.js
+++ b/src/lib/sound.js
@@ -1,0 +1,47 @@
+let ctx = null;
+
+function getCtx() {
+  if (!ctx) {
+    const Ctor = window.AudioContext || window.webkitAudioContext;
+    if (!Ctor) return null;
+    ctx = new Ctor();
+  }
+  return ctx;
+}
+
+/**
+ * Resume the AudioContext after a user gesture — call this on the tap that
+ * starts the rest timer so the ding can play later without interaction.
+ */
+export function unlockAudio() {
+  const c = getCtx();
+  if (c?.state === "suspended") c.resume();
+}
+
+/**
+ * Play a short bell-like ding (two sine harmonics with exponential decay).
+ * Synthesised via Web Audio API — no file to load, works offline.
+ */
+export function playDing() {
+  const c = getCtx();
+  if (!c) return;
+  if (c.state === "suspended") c.resume();
+
+  const now = c.currentTime;
+
+  const play = (freq, vol, dur) => {
+    const osc = c.createOscillator();
+    const gain = c.createGain();
+    osc.type = "sine";
+    osc.frequency.value = freq;
+    gain.gain.setValueAtTime(vol, now);
+    gain.gain.exponentialRampToValueAtTime(0.001, now + dur);
+    osc.connect(gain).connect(c.destination);
+    osc.start(now);
+    osc.stop(now + dur);
+  };
+
+  play(830, 0.3, 1.0);
+  play(1245, 0.15, 0.6);
+  play(1660, 0.08, 0.4);
+}

--- a/src/lib/sound.test.js
+++ b/src/lib/sound.test.js
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+function mockAudioContext() {
+  const ctx = {
+    state: "suspended",
+    currentTime: 0,
+    destination: {},
+    resume: vi.fn(() => {
+      ctx.state = "running";
+    }),
+    createOscillator: vi.fn(() => ({
+      type: "",
+      frequency: { value: 0 },
+      connect: vi.fn().mockReturnThis(),
+      start: vi.fn(),
+      stop: vi.fn(),
+    })),
+    createGain: vi.fn(() => ({
+      gain: { setValueAtTime: vi.fn(), exponentialRampToValueAtTime: vi.fn() },
+      connect: vi.fn().mockReturnThis(),
+    })),
+  };
+  return ctx;
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.stubGlobal("AudioContext", vi.fn(mockAudioContext));
+  vi.unstubAllGlobals;
+});
+
+describe("no AudioContext available", () => {
+  it("unlockAudio is a no-op", async () => {
+    delete globalThis.AudioContext;
+    delete globalThis.webkitAudioContext;
+    const { unlockAudio } = await import("./sound");
+    expect(() => unlockAudio()).not.toThrow();
+  });
+
+  it("playDing is a no-op", async () => {
+    delete globalThis.AudioContext;
+    delete globalThis.webkitAudioContext;
+    const { playDing } = await import("./sound");
+    expect(() => playDing()).not.toThrow();
+  });
+});
+
+describe("unlockAudio", () => {
+  it("resumes a suspended AudioContext", async () => {
+    const { unlockAudio } = await import("./sound");
+    unlockAudio();
+    const ctx = AudioContext.mock.results[0].value;
+    expect(ctx.resume).toHaveBeenCalled();
+    expect(ctx.state).toBe("running");
+  });
+
+  it("does not resume an already-running context", async () => {
+    const { unlockAudio } = await import("./sound");
+    unlockAudio(); // first call creates + resumes
+    const ctx = AudioContext.mock.results[0].value;
+    ctx.resume.mockClear();
+    ctx.state = "running";
+    unlockAudio();
+    expect(ctx.resume).not.toHaveBeenCalled();
+  });
+});
+
+describe("playDing", () => {
+  it("creates oscillators and gain nodes for each harmonic", async () => {
+    const { playDing } = await import("./sound");
+    playDing();
+    const ctx = AudioContext.mock.results[0].value;
+    expect(ctx.createOscillator).toHaveBeenCalledTimes(3);
+    expect(ctx.createGain).toHaveBeenCalledTimes(3);
+  });
+
+  it("starts and stops each oscillator", async () => {
+    const { playDing } = await import("./sound");
+    playDing();
+    const ctx = AudioContext.mock.results[0].value;
+    for (const { value: osc } of ctx.createOscillator.mock.results) {
+      expect(osc.start).toHaveBeenCalledOnce();
+      expect(osc.stop).toHaveBeenCalledOnce();
+    }
+  });
+
+  it("reuses the same AudioContext across calls", async () => {
+    const { playDing } = await import("./sound");
+    playDing();
+    playDing();
+    expect(AudioContext).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Add a synthesized bell-like ding sound (Web Audio API, three sine harmonics) that plays when the rest timer countdown reaches zero
- Unlock the AudioContext on the user's tap that starts the timer, so mobile browsers (iOS Safari, Android Chrome) allow playback later without additional interaction
- Gracefully no-op when AudioContext is unavailable (e.g. in jsdom test environment)

## Details
- New `src/lib/sound.js` — `unlockAudio()` and `playDing()` utilities; no external audio files, works fully offline
- `LiveSession.jsx` — a `useEffect` watches `restLeft` and fires `playDing()` on the transition from counting to zero; `unlockAudio()` is called in the rest-preset button's `onClick`
- `src/lib/sound.test.js` — 7 tests covering oscillator creation, context reuse, and graceful degradation

## Test plan
- [x] `npm run check` passes (300 tests, lint, format, build)
- [ ] On mobile browser: start a live session, tap a rest preset, wait for countdown to hit 0 — a ding should play
- [ ] Verify ding plays even if the tab was backgrounded during the countdown
- [ ] Verify no crash/error in browsers without AudioContext support

🤖 Generated with [Claude Code](https://claude.com/claude-code)