### PR TITLE
Add total reps summary to exercise history modal

### DIFF
--- a/src/components/ExerciseHistoryModal.jsx
+++ b/src/components/ExerciseHistoryModal.jsx
@@ -80,6 +80,11 @@ export default function ExerciseHistoryModal({
                     </Badge>
                   ))}
                 </div>
+                {/* Total reps */}
+                <div className="ml-4 text-xs text-neutral-500 dark:text-neutral-400">
+                  Total: {item.sets.reduce((sum, s) => sum + (s.reps || 0), 0)}{" "}
+                  reps
+                </div>
                 {/* RPE + feedback, when logged */}
                 <div className="ml-4">
                   <RpeFeedback


### PR DESCRIPTION
## Summary
- Show a **Total: X reps** line below the per-set badges in the exercise history modal, summing reps across all sets for each workout entry
- Gives a quick glance at volume per session without mental math

## Test plan
- [x] All 300 existing tests pass
- [x] Lint, format, and build pass
- [ ] Open the exercise history modal on a workout with logged sets — verify the total reps line appears and is correct
- [ ] Check with exercises that have varying rep counts across sets

🤖 Generated with [Claude Code](https://claude.com/claude-code)